### PR TITLE
[sailfish-connman-plugin-iptables] Fix e-t-e tests and cleanup code. Fixes JB#61353

### DIFF
--- a/rpm/sailfish-iptables-api-plugin.spec
+++ b/rpm/sailfish-iptables-api-plugin.spec
@@ -50,7 +50,7 @@ This package contains the unit tests and unit test runner script for Sailfish Co
 Summary:    Test scripts for Sailfish Connman iptables management plugin
 Requires:   %{name} = %{version}
 Requires:   connman >= 1.32+git9
-Requires:   bash
+Requires:   gnu-bash
 Requires:   dbus >= 1.4
 Requires:   iptables
 Requires:   nemo-test-tools

--- a/src/sailfish-iptables-dbus.c
+++ b/src/sailfish-iptables-dbus.c
@@ -3,25 +3,25 @@
  *  Sailfish Connection Manager iptables plugin
  *
  *  BSD 3-Clause License
- * 
+ *
  *  Copyright (c) 2017-2018, Jolla Ltd.
  *  Contact: Jussi Laakkonen <jussi.laakkonen@jolla.com>
  *  All rights reserved.
-
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- * 
+ *
  *  Redistributions of source code must retain the above copyright notice, this
  *  list of conditions and the following disclaimer.
- * 
+ *
  *  Redistributions in binary form must reproduce the above copyright notice,
  *  this list of conditions and the following disclaimer in the documentation
  *  and/or other materials provided with the distribution.
- * 
+ *
  *  Neither the name of the copyright holder nor the names of its
  *  contributors may be used to endorse or promote products derived from
  *  this software without specific prior written permission.
-
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -34,7 +34,7 @@
  *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  */
- 
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -56,7 +56,7 @@
 
 /*
 	Result codes (enum sailfish_iptables_result):
-	
+
 	0 = "Ok",
 	1 = "Invalid IP",
 	2 = "Invalid port",
@@ -76,56 +76,61 @@
 	100 = "Access denied",
 */
 
-#define SAILFISH_IPTABLES_RESULT_TYPE			{"result", "q"}
-#define SAILFISH_IPTABLES_RESULT_STRING			{"string", "s"}
-#define SAILFISH_IPTABLES_RESULT_VERSION		{"version", "i"}
-#define SAILFISH_IPTABLES_RESULT_CHAINS			{"chains", "as"}
-#define SAILFISH_IPTABLES_RESULT_RULES			{"rules", "as"}
+#define SAILFISH_IPTABLES_RESULT_TYPE		{"result", "q"}
+#define SAILFISH_IPTABLES_RESULT_STRING		{"string", "s"}
+#define SAILFISH_IPTABLES_RESULT_VERSION	{"version", "i"}
+#define SAILFISH_IPTABLES_RESULT_CHAINS		{"chains", "as"}
+#define SAILFISH_IPTABLES_RESULT_RULES		{"rules", "as"}
 
 
-#define SAILFISH_IPTABLES_INPUT_ABSOLUTE_PATH		{"absolute_path","s"}
-#define SAILFISH_IPTABLES_INPUT_IP			{"ip","s"}
-#define SAILFISH_IPTABLES_INPUT_IP_SRC			{"source_ip", "s"}
-#define SAILFISH_IPTABLES_INPUT_IP_DST			{"destination_ip", "s"}
-#define SAILFISH_IPTABLES_INPUT_PORT			{"port","q"}
-#define SAILFISH_IPTABLES_INPUT_PORT_SRC		{"source_port","q"}
-#define SAILFISH_IPTABLES_INPUT_PORT_DST		{"destination_port","q"}
-#define SAILFISH_IPTABLES_INPUT_PORT_SRC_A		{"source_port_start","q"}
-#define SAILFISH_IPTABLES_INPUT_PORT_SRC_B		{"source_port_end","q"}
-#define SAILFISH_IPTABLES_INPUT_PORT_DST_A		{"destination_port_start","q"}
-#define SAILFISH_IPTABLES_INPUT_PORT_DST_B		{"destination_port_end","q"}
-#define SAILFISH_IPTABLES_INPUT_SERVICE_SRC		{"source_service","s"}
-#define SAILFISH_IPTABLES_INPUT_SERVICE_DST		{"destination_service","s"}
-#define SAILFISH_IPTABLES_INPUT_PROTOCOL_STR		{"protocol","s"}
-#define SAILFISH_IPTABLES_INPUT_PROTOCOL		{"protocol","u"}
-#define SAILFISH_IPTABLES_INPUT_OPERATION		{"operation","q"}
-#define SAILFISH_IPTABLES_INPUT_POLICY_INT		{"policy", "q"}
-#define SAILFISH_IPTABLES_INPUT_TABLE			{"table", "s"}
-#define SAILFISH_IPTABLES_INPUT_CHAIN			{"chain", "s"}
-#define SAILFISH_IPTABLES_INPUT_TARGET			{"target", "s"}
-#define SAILFISH_IPTABLES_INPUT_ICMP_TYPE		{"icmp_type", "q"}
-#define SAILFISH_IPTABLES_INPUT_ICMP_CODE		{"icmp_code", "q"}
+#define SAILFISH_IPTABLES_INPUT_ABSOLUTE_PATH	{"absolute_path","s"}
+#define SAILFISH_IPTABLES_INPUT_IP		{"ip","s"}
+#define SAILFISH_IPTABLES_INPUT_IP_SRC		{"source_ip", "s"}
+#define SAILFISH_IPTABLES_INPUT_IP_DST		{"destination_ip", "s"}
+#define SAILFISH_IPTABLES_INPUT_PORT		{"port","q"}
+#define SAILFISH_IPTABLES_INPUT_PORT_SRC	{"source_port","q"}
+#define SAILFISH_IPTABLES_INPUT_PORT_DST	{"destination_port","q"}
+#define SAILFISH_IPTABLES_INPUT_PORT_SRC_A	{"source_port_start","q"}
+#define SAILFISH_IPTABLES_INPUT_PORT_SRC_B	{"source_port_end","q"}
+#define SAILFISH_IPTABLES_INPUT_PORT_DST_A	{"destination_port_start","q"}
+#define SAILFISH_IPTABLES_INPUT_PORT_DST_B	{"destination_port_end","q"}
+#define SAILFISH_IPTABLES_INPUT_SERVICE_SRC	{"source_service","s"}
+#define SAILFISH_IPTABLES_INPUT_SERVICE_DST	{"destination_service","s"}
+#define SAILFISH_IPTABLES_INPUT_PROTOCOL_STR	{"protocol","s"}
+#define SAILFISH_IPTABLES_INPUT_PROTOCOL	{"protocol","u"}
+#define SAILFISH_IPTABLES_INPUT_OPERATION	{"operation","q"}
+#define SAILFISH_IPTABLES_INPUT_POLICY_INT	{"policy", "q"}
+#define SAILFISH_IPTABLES_INPUT_TABLE		{"table", "s"}
+#define SAILFISH_IPTABLES_INPUT_CHAIN		{"chain", "s"}
+#define SAILFISH_IPTABLES_INPUT_TARGET		{"target", "s"}
+#define SAILFISH_IPTABLES_INPUT_ICMP_TYPE	{"icmp_type", "q"}
+#define SAILFISH_IPTABLES_INPUT_ICMP_CODE	{"icmp_code", "q"}
 
-#define SAILFISH_IPTABLES_SIGNAL_POLICY_CHAIN		SAILFISH_IPTABLES_INPUT_CHAIN
-#define SAILFISH_IPTABLES_SIGNAL_POLICY_TYPE		{"policy", "s"}
-#define SAILFISH_IPTABLES_SIGNAL_TABLE			SAILFISH_IPTABLES_INPUT_TABLE
+#define SAILFISH_IPTABLES_SIGNAL_POLICY_CHAIN	SAILFISH_IPTABLES_INPUT_CHAIN
+#define SAILFISH_IPTABLES_SIGNAL_POLICY_TYPE	{"policy", "s"}
+#define SAILFISH_IPTABLES_SIGNAL_TABLE		SAILFISH_IPTABLES_INPUT_TABLE
 
 /* These prototypes are connected to dbus */
 
 static DBusMessage* sailfish_iptables_register_client(
-			DBusConnection* connection, DBusMessage* message, void *user_data);
-			
+			DBusConnection* connection, DBusMessage* message,
+			void *user_data);
+
 static DBusMessage* sailfish_iptables_unregister_client(
-			DBusConnection* connection, DBusMessage* message, void *user_data);
+			DBusConnection* connection, DBusMessage* message,
+			void *user_data);
 
 static DBusMessage* sailfish_iptables_clear_iptables_rules(
-			DBusConnection *connection, DBusMessage *message, void *user_data);
-			
+			DBusConnection *connection, DBusMessage *message,
+			void *user_data);
+
 static DBusMessage* sailfish_iptables_clear_iptables_chains(
-			DBusConnection *connection, DBusMessage *message, void *user_data);
-			
+			DBusConnection *connection, DBusMessage *message,
+			void *user_data);
+
 static DBusMessage* sailfish_iptables_get_iptables_content(
-			DBusConnection *connection, DBusMessage *message, void *user_data);
+			DBusConnection *connection, DBusMessage *message,
+			void *user_data);
 
 static DBusMessage* sailfish_iptables_version(DBusConnection *connection,
 			DBusMessage *message, void *user_data);
@@ -136,36 +141,44 @@ static DBusMessage* sailfish_iptables_change_policy(
 
 // New api functions
 static DBusMessage* sailfish_iptables_rule_ip(
-			DBusConnection *connection,	DBusMessage *message, void *user_data);
+			DBusConnection *connection, DBusMessage *message,
+			void *user_data);
 
 static DBusMessage* sailfish_iptables_rule_ip_port(
-			DBusConnection *connection,	DBusMessage *message, void *user_data);
+			DBusConnection *connection, DBusMessage *message,
+			void *user_data);
 
 static DBusMessage* sailfish_iptables_rule_ip_port_range(
-			DBusConnection *connection,	DBusMessage *message, void *user_data);
+			DBusConnection *connection, DBusMessage *message,
+			void *user_data);
 
 static DBusMessage* sailfish_iptables_rule_port(
-			DBusConnection *connection,	DBusMessage *message, void *user_data);
+			DBusConnection *connection, DBusMessage *message,
+			void *user_data);
 
 static DBusMessage* sailfish_iptables_rule_port_range(
-			DBusConnection *connection,	DBusMessage *message, void *user_data);
+			DBusConnection *connection, DBusMessage *message,
+			void *user_data);
 
 static DBusMessage* sailfish_iptables_rule_ip_service(
-			DBusConnection *connection,	DBusMessage *message, void *user_data);
+			DBusConnection *connection, DBusMessage *message,
+			void *user_data);
 
 static DBusMessage* sailfish_iptables_rule_service(
-			DBusConnection *connection,	DBusMessage *message, void *user_data);
+			DBusConnection *connection, DBusMessage *message,
+			void *user_data);
 
 // Chain management
 static DBusMessage* sailfish_iptables_manage_chain(
-			DBusConnection *connection,	DBusMessage *message, void *user_data);
+			DBusConnection *connection, DBusMessage *message,
+			void *user_data);
 
 // ICMP
 static DBusMessage* sailfish_iptables_icmp_rule(
 				DBusConnection *connection,
 				DBusMessage *message, void *user_data);
 
-const gchar const * OP_STR[] = {"Add", "Remove", "Undefined", NULL};
+const gchar *OP_STR[] = {"Add", "Remove", "Undefined", NULL};
 
 // Signal names are defined in sailfish_iptables_dbus.h
 static const GDBusSignalTable signals[] = {
@@ -193,8 +206,9 @@ static const GDBusSignalTable signals[] = {
 			SAILFISH_IPTABLES_SIGNAL_POLICY,
 			GDBUS_ARGS(
 				SAILFISH_IPTABLES_SIGNAL_TABLE,
-				SAILFISH_IPTABLES_SIGNAL_POLICY_CHAIN, 
-				SAILFISH_IPTABLES_SIGNAL_POLICY_TYPE))
+				SAILFISH_IPTABLES_SIGNAL_POLICY_CHAIN,
+				SAILFISH_IPTABLES_SIGNAL_POLICY_TYPE
+			))
 		},
 		{ GDBUS_SIGNAL(
 			SAILFISH_IPTABLES_SIGNAL_CHAIN,
@@ -260,35 +274,35 @@ static const GDBusSignalTable signals[] = {
 		},
 		{ }
 	};
-	
+
 static const GDBusMethodTable methods[] = {
-		{ GDBUS_METHOD(SAILFISH_IPTABLES_REGISTER_CLIENT, 
+		{ GDBUS_METHOD(SAILFISH_IPTABLES_REGISTER_CLIENT,
 			NULL,
 			GDBUS_ARGS(
 				SAILFISH_IPTABLES_RESULT_TYPE
 			),
 			sailfish_iptables_register_client)
 		},
-		{ GDBUS_METHOD(SAILFISH_IPTABLES_UNREGISTER_CLIENT, 
+		{ GDBUS_METHOD(SAILFISH_IPTABLES_UNREGISTER_CLIENT,
 			NULL,
 			GDBUS_ARGS(
 				SAILFISH_IPTABLES_RESULT_TYPE
 			),
 			sailfish_iptables_unregister_client)
 		},
-		{ GDBUS_METHOD(SAILFISH_IPTABLES_CLEAR_IPTABLES_TABLE, 
+		{ GDBUS_METHOD(SAILFISH_IPTABLES_CLEAR_IPTABLES_TABLE,
 			GDBUS_ARGS(SAILFISH_IPTABLES_INPUT_TABLE),
 			GDBUS_ARGS(
 				SAILFISH_IPTABLES_RESULT_TYPE),
 			sailfish_iptables_clear_iptables_rules)
 		},
-		{ GDBUS_METHOD(SAILFISH_IPTABLES_CLEAR_IPTABLES_CHAINS, 
+		{ GDBUS_METHOD(SAILFISH_IPTABLES_CLEAR_IPTABLES_CHAINS,
 			GDBUS_ARGS(SAILFISH_IPTABLES_INPUT_TABLE),
 			GDBUS_ARGS(
 				SAILFISH_IPTABLES_RESULT_TYPE),
 			sailfish_iptables_clear_iptables_chains)
 		},
-		{ GDBUS_METHOD(SAILFISH_IPTABLES_GET_IPTABLES_CONTENT, 
+		{ GDBUS_METHOD(SAILFISH_IPTABLES_GET_IPTABLES_CONTENT,
 			GDBUS_ARGS(SAILFISH_IPTABLES_INPUT_TABLE),
 			GDBUS_ARGS(
 				SAILFISH_IPTABLES_RESULT_TYPE,
@@ -297,7 +311,7 @@ static const GDBusMethodTable methods[] = {
 				),
 			sailfish_iptables_get_iptables_content)
 		},
-		{ GDBUS_METHOD(SAILFISH_IPTABLES_MANAGE_CHAIN, 
+		{ GDBUS_METHOD(SAILFISH_IPTABLES_MANAGE_CHAIN,
 			GDBUS_ARGS(
 				SAILFISH_IPTABLES_INPUT_TABLE,
 				SAILFISH_IPTABLES_INPUT_CHAIN,
@@ -307,7 +321,7 @@ static const GDBusMethodTable methods[] = {
 			),
 			sailfish_iptables_manage_chain)
 		},
-		{ GDBUS_METHOD(SAILFISH_IPTABLES_CHANGE_POLICY, 
+		{ GDBUS_METHOD(SAILFISH_IPTABLES_CHANGE_POLICY,
 			GDBUS_ARGS(
 				SAILFISH_IPTABLES_INPUT_TABLE,
 				SAILFISH_IPTABLES_INPUT_CHAIN,
@@ -445,7 +459,7 @@ static const GDBusMethodTable methods[] = {
 			),
 			sailfish_iptables_icmp_rule)
 		},
-		{ GDBUS_METHOD(SAILFISH_IPTABLES_GET_VERSION, 
+		{ GDBUS_METHOD(SAILFISH_IPTABLES_GET_VERSION,
 			NULL,
 			GDBUS_ARGS(SAILFISH_IPTABLES_RESULT_VERSION),
 			sailfish_iptables_version)
@@ -455,12 +469,12 @@ static const GDBusMethodTable methods[] = {
 
 static void dbus_client_destroy(void *user_data)
 {
-	if(user_data)
-	{
-		client_disconnect_data *data = (client_disconnect_data*)user_data;
-	
+	if(user_data) {
+		client_disconnect_data *data =
+					(client_disconnect_data*)user_data;
+
 		api_data_remove_peer(data->main_data, data->client_name);
-	
+
 		client_disconnect_data_free(data);
 	}
 }
@@ -476,51 +490,51 @@ DBusMessage* sailfish_iptables_register_client(DBusConnection* connection,
 {
 	api_data *data = (api_data*)user_data;
 	api_result result = OK;
-	
+
 	DAPeer* peer = sailfish_iptables_policy_get_peer(message, data);
-	
+
 	if(peer && sailfish_iptables_policy_check_peer(data, peer,
-		SAILFISH_DBUS_ACCESS_LISTEN))
-	{
+		SAILFISH_DBUS_ACCESS_LISTEN)) {
 		dbus_client *client = dbus_client_new();
 
 		client->peer = da_peer_ref(peer);
 
-		client_disconnect_data* disconnect_data = client_disconnect_data_new(
-			data, client);
+		client_disconnect_data* disconnect_data =
+				client_disconnect_data_new(data, client);
 
 		client->watch_id = g_dbus_add_disconnect_watch(connection,
-			client->peer->name, dbus_client_disconnected, disconnect_data,
+			client->peer->name, dbus_client_disconnected,
+				disconnect_data,
 			NULL);
 
 		if(client->watch_id)
 			api_data_add_peer(data,client);
-		else
-		{
+		else {
 			dbus_client_free(client);
 			client_disconnect_data_free(disconnect_data);
-			result = UNAUTHORIZED; // Couldn't add -> not authorized, try again
+			// Couldn't add -> not authorized, try again
+			result = UNAUTHORIZED;
 			DBG("%s %s %s", PLUGIN_NAME,
-				"sailfish_iptables_register_client failed for", peer->name);
+				"sailfish_iptables_register_client failed for",
+				peer->name);
 		}
-	}
-	else
+	} else
 		result = ACCESS_DENIED;
-	
+
 	return sailfish_iptables_dbus_reply_result(message, result, NULL);
 }
-			
+
 DBusMessage* sailfish_iptables_unregister_client(DBusConnection* connection,
 			DBusMessage* message, void *user_data)
 {
 	api_data *data = (api_data*)user_data;
 	api_result result = OK;
-	
+
 	const gchar* sender = dbus_message_get_sender(message);
-	
+
 	if(!api_data_remove_peer(data,sender))
 		result = REMOVE_FAILED;
-	
+
 	return sailfish_iptables_dbus_reply_result(message, result, NULL);
 }
 
@@ -534,8 +548,8 @@ DBusMessage* sailfish_iptables_clear_iptables_rules(DBusConnection *connection,
 DBusMessage* sailfish_iptables_clear_iptables_chains(DBusConnection *connection,
 			DBusMessage *message, void *user_data)
 {
-	return process_request(message, &clear_iptables_chains, ARGS_CLEAR_CHAINS,
-		user_data);
+	return process_request(message, &clear_iptables_chains,
+		ARGS_CLEAR_CHAINS, user_data);
 }
 
 DBusMessage* sailfish_iptables_get_iptables_content(DBusConnection *connection,
@@ -561,63 +575,72 @@ DBusMessage* sailfish_iptables_version(DBusConnection *connection,
 }
 
 DBusMessage* sailfish_iptables_change_policy(
-			DBusConnection *connection,	DBusMessage *message, void *user_data)
+			DBusConnection *connection, DBusMessage *message,
+			void *user_data)
 {
 	return process_request(message, &set_policy, ARGS_POLICY, user_data);
 }
 
-// Rules 
+// Rules
 DBusMessage* sailfish_iptables_rule_ip(
-			DBusConnection *connection,	DBusMessage *message, void *user_data)
+			DBusConnection *connection, DBusMessage *message,
+			void *user_data)
 {
 	return process_request(message, &add_rule_to_iptables, ARGS_IP,
 		user_data);
 }
 
 DBusMessage* sailfish_iptables_rule_ip_port(
-			DBusConnection *connection,	DBusMessage *message, void *user_data)
+			DBusConnection *connection, DBusMessage *message,
+			void *user_data)
 {
 	return process_request(message, &add_rule_to_iptables, ARGS_IP_PORT,
 		user_data);
 }
 
 DBusMessage* sailfish_iptables_rule_ip_port_range(
-			DBusConnection *connection,	DBusMessage *message, void *user_data)
+			DBusConnection *connection, DBusMessage *message,
+			void *user_data)
 {
-	return process_request(message, &add_rule_to_iptables, ARGS_IP_PORT_RANGE,
-		user_data);
+	return process_request(message, &add_rule_to_iptables,
+		ARGS_IP_PORT_RANGE, user_data);
 }
 
 DBusMessage* sailfish_iptables_rule_port(
-			DBusConnection *connection,	DBusMessage *message, void *user_data)
+			DBusConnection *connection, DBusMessage *message,
+			void *user_data)
 {
 	return process_request(message, &add_rule_to_iptables, ARGS_PORT,
 		user_data);
 }
 
 DBusMessage* sailfish_iptables_rule_port_range(
-			DBusConnection *connection,	DBusMessage *message, void *user_data)
+			DBusConnection *connection, DBusMessage *message,
+			void *user_data)
 {
 	return process_request(message, &add_rule_to_iptables, ARGS_PORT_RANGE,
 		user_data);
 }
 
 DBusMessage* sailfish_iptables_rule_ip_service(
-			DBusConnection *connection,	DBusMessage *message, void *user_data)
+			DBusConnection *connection, DBusMessage *message,
+			void *user_data)
 {
 	return process_request(message, &add_rule_to_iptables, ARGS_IP_SERVICE,
 		user_data);
 }
 
 DBusMessage* sailfish_iptables_rule_service(
-			DBusConnection *connection,	DBusMessage *message, void *user_data)
+			DBusConnection *connection, DBusMessage *message,
+			void *user_data)
 {
 	return process_request(message, &add_rule_to_iptables, ARGS_SERVICE,
 		user_data);
 }
 
 DBusMessage* sailfish_iptables_manage_chain(
-			DBusConnection *connection,	DBusMessage *message, void *user_data)
+			DBusConnection *connection, DBusMessage *message,
+			void *user_data)
 {
 	return process_request(message, &manage_chain, ARGS_CHAIN, user_data);
 }
@@ -634,31 +657,31 @@ void sailfish_iptables_dbus_send_signal(DBusMessage *signal, api_data* data)
 {
 	DBusConnection* conn = 	connman_dbus_get_connection();
 
-	if(conn)
-	{
+	if(conn) {
 		// Send to all
 		if(!data)
 			g_dbus_send_message(conn,signal);
-			
+
 		// Send to registered clients only
-		else if (g_hash_table_size(data->clients))
-		{
+		else if (g_hash_table_size(data->clients)) {
 			GHashTableIter iter;
 			gpointer key = NULL;
-			
+
 			g_hash_table_iter_init(&iter, data->clients);
-			
+
 			while(g_hash_table_iter_next(&iter, &key, NULL)) {
 				DBusMessage *copy = dbus_message_copy(signal);
-				dbus_message_set_destination(copy, (const gchar*)key);
+				dbus_message_set_destination(copy,
+							(const gchar*)key);
 				g_dbus_send_message(conn, copy);
-				DBG("%s %s %s", PLUGIN_NAME, 
-					"sailfish_iptables_dbus_send_signal to", (const gchar*)key);
+				DBG("%s %s %s", PLUGIN_NAME,
+					"sailfish_iptables_dbus_send_signal to",
+					(const gchar*)key);
 			}
-			
+
 			dbus_message_unref(signal);
 		}
-		
+
 		dbus_connection_unref(conn);
 	}
 }
@@ -668,25 +691,25 @@ DBusMessage* sailfish_iptables_dbus_signal(const gchar* signal_name,
 {
 	if(!signal_name || !*signal_name)
 		return NULL;
-	
+
 	DBusMessage *signal = dbus_message_new_signal(
 					SAILFISH_IPTABLES_DBUS_PATH,
 					SAILFISH_IPTABLES_DBUS_INTERFACE,
 					signal_name);
-					
-	if(first_arg_type != DBUS_TYPE_INVALID && signal)
-	{
+
+	if(first_arg_type != DBUS_TYPE_INVALID && signal) {
 		va_list params;
 		va_start(params,first_arg_type);
-		
-		if(!dbus_message_append_args_valist(signal, first_arg_type, params))
-		{
-			ERR("%s %s %s", PLUGIN_NAME, "saifish_iptables_dbus_signal():",
+
+		if(!dbus_message_append_args_valist(signal, first_arg_type,
+								params)) {
+			ERR("%s %s ", PLUGIN_NAME,
+				"saifish_iptables_dbus_signal(): "
 				"failed to add parameters to signal");
 			dbus_message_unref(signal);
 			signal = NULL;
 		}
-		
+
 		va_end(params);
 	}
 	return signal;
@@ -702,46 +725,45 @@ DBusMessage* sailfish_iptables_dbus_reply_result(DBusMessage *message,
 		reply = g_dbus_create_reply(message,
 			DBUS_TYPE_UINT16,	&res,
 			DBUS_TYPE_INVALID);
-	
-	else if(params->iptables_content)
-	{
+
+	else if(params->iptables_content) {
 		DBusMessageIter iter, array;
 		GList *list_iter = NULL;
-		
+
 		reply = dbus_message_new_method_return(message);
-			
+
 		dbus_message_iter_init_append(reply, &iter);
-		
+
 		dbus_message_iter_append_basic(&iter, DBUS_TYPE_UINT16, &res);
-		
+
 		// Chains
 		dbus_message_iter_open_container(&iter, DBUS_TYPE_ARRAY,
 			DBUS_TYPE_STRING_AS_STRING, &array);
-			
+
 		for(list_iter = params->iptables_content->chains ;
 			list_iter ;
-			list_iter = list_iter->next)
-		{
+			list_iter = list_iter->next) {
 			gchar* content = (gchar*)list_iter->data;
-			dbus_message_iter_append_basic(&array, DBUS_TYPE_STRING, &content);
+			dbus_message_iter_append_basic(&array, DBUS_TYPE_STRING,
+				&content);
 		}
-		
+
 		dbus_message_iter_close_container(&iter, &array);
-		
+
 		// Rules
 		dbus_message_iter_open_container(&iter, DBUS_TYPE_ARRAY,
 			DBUS_TYPE_STRING_AS_STRING, &array);
-			
+
 		for(list_iter = params->iptables_content->rules ;
 			list_iter ;
-			list_iter = list_iter->next)
-		{
+			list_iter = list_iter->next) {
 			gchar* content = (gchar*)list_iter->data;
-			dbus_message_iter_append_basic(&array, DBUS_TYPE_STRING, &content);
+			dbus_message_iter_append_basic(&array, DBUS_TYPE_STRING,
+				&content);
 		}
-		
+
 		dbus_message_iter_close_container(&iter, &array);
-		
+
 		// Last
 		dbus_message_append_args(reply, DBUS_TYPE_INVALID);
 	}
@@ -749,117 +771,128 @@ DBusMessage* sailfish_iptables_dbus_reply_result(DBusMessage *message,
 	if(!reply)
 		reply = g_dbus_create_error(message,DBUS_ERROR_NO_MEMORY,
 			"failed to add parameters to reply.");
-	
+
 	rule_params_free(params);
-	
+
 	return reply;
 }
 
-DBusMessage* sailfish_iptables_dbus_signal_from_rule_params(rule_params* params)
+DBusMessage* sailfish_iptables_dbus_signal_from_rule_params(
+							rule_params* params)
 {
 	DBusMessage* signal = NULL;
 	gchar *empty = EMPTY_STR;
 	const gchar* signal_name = NULL;
 
-	switch(params->args)
-	{
-		case ARGS_IP:
-		case ARGS_IP_PORT:
-		case ARGS_IP_PORT_RANGE:
-		case ARGS_IP_SERVICE:
-		case ARGS_PORT:
-		case ARGS_PORT_RANGE:
-		case ARGS_SERVICE:
-			switch(params->operation)
-			{
-				case ADD:
-					signal_name = SAILFISH_IPTABLES_SIGNAL_RULE_ADD;
-					break;
-				case REMOVE:
-					signal_name = SAILFISH_IPTABLES_SIGNAL_RULE_REM;
-					break;
-				// Rules can be only added or removed
-				default:
-					return NULL;
-			}
-			signal = sailfish_iptables_dbus_signal(
-				signal_name,
-				DBUS_TYPE_STRING,	params->table ? &(params->table) : &empty,
-				DBUS_TYPE_STRING,	params->chain ? &(params->chain) : &empty,
-				DBUS_TYPE_STRING,	params->target ? &(params->target) : &empty,
-				DBUS_TYPE_STRING,	params->ip_src ? &(params->ip_src) : &empty,
-				DBUS_TYPE_STRING,	params->ip_dst ? &(params->ip_dst) : &empty,
-				DBUS_TYPE_UINT16,	&(params->port_src[0]),
-				DBUS_TYPE_UINT16,	&(params->port_src[1]),
-				DBUS_TYPE_UINT16,	&(params->port_dst[0]),
-				DBUS_TYPE_UINT16,	&(params->port_dst[1]),
-				DBUS_TYPE_STRING,	params->protocol ? &(params->protocol) : 
-					&empty,
-				DBUS_TYPE_INVALID);
+	switch(params->args) {
+	case ARGS_IP:
+	case ARGS_IP_PORT:
+	case ARGS_IP_PORT_RANGE:
+	case ARGS_IP_SERVICE:
+	case ARGS_PORT:
+	case ARGS_PORT_RANGE:
+	case ARGS_SERVICE:
+		switch(params->operation) {
+		case ADD:
+			signal_name = SAILFISH_IPTABLES_SIGNAL_RULE_ADD;
 			break;
-		case ARGS_CLEAR:
-			signal = sailfish_iptables_dbus_signal(
-				SAILFISH_IPTABLES_SIGNAL_CLEAR,
-				DBUS_TYPE_STRING,	params->table ? &(params->table) : &empty,
-				DBUS_TYPE_INVALID);
+		case REMOVE:
+			signal_name = SAILFISH_IPTABLES_SIGNAL_RULE_REM;
 			break;
-		case ARGS_CLEAR_CHAINS:
-			signal = sailfish_iptables_dbus_signal(
-				SAILFISH_IPTABLES_SIGNAL_CLEAR_CHAINS,
-				DBUS_TYPE_STRING,	params->table ? &(params->table) : &empty,
-				DBUS_TYPE_INVALID);
-			break;
-		case ARGS_POLICY:
-			signal = sailfish_iptables_dbus_signal(
-				SAILFISH_IPTABLES_SIGNAL_POLICY,
-				DBUS_TYPE_STRING,	params->table ? &(params->table) : &empty,
-				DBUS_TYPE_STRING,	params->chain ? &(params->chain) : &empty,
-				DBUS_TYPE_STRING,	params->policy ? &(params->policy) : &empty,
-				DBUS_TYPE_INVALID);
-			break;
-		case ARGS_CHAIN:
-			signal = sailfish_iptables_dbus_signal(
-				SAILFISH_IPTABLES_SIGNAL_CHAIN,
-				DBUS_TYPE_STRING,	params->table ? &(params->table) : &empty,
-				DBUS_TYPE_STRING,	params->chain ? &(params->chain) : &empty,
-				DBUS_TYPE_UINT16,	&(params->operation),
-				DBUS_TYPE_INVALID);
-		case ARGS_IP_ICMP:
-		case ARGS_ICMP:
-			switch(params->operation)
-			{
-				case ADD:
-					signal_name =
-						SAILFISH_IPTABLES_SIGNAL_ICMP_ADD;
-					break;
-				case REMOVE:
-					signal_name =
-						SAILFISH_IPTABLES_SIGNAL_ICMP_REM;
-					break;
-				// Rules can be only added or removed
-				default:
-					return NULL;
-			}
-			signal = sailfish_iptables_dbus_signal(
-				signal_name,
-				DBUS_TYPE_STRING,
-				params->table ? &(params->table) : &empty,
-				DBUS_TYPE_STRING,
-				params->chain ? &(params->chain) : &empty,
-				DBUS_TYPE_STRING,
-				params->target ? &(params->target) : &empty,
-				DBUS_TYPE_STRING,
-				params->ip_src ? &(params->ip_src) : &empty,
-				DBUS_TYPE_STRING,
-				params->ip_dst ? &(params->ip_dst) : &empty,
-				DBUS_TYPE_UINT16,
-				&(params->icmp[0]),
-				DBUS_TYPE_UINT16,
-				&(params->icmp[1]),
-				DBUS_TYPE_INVALID);
-			break;
+		// Rules can be only added or removed
 		default:
+			return NULL;
+		}
+		signal = sailfish_iptables_dbus_signal(
+			signal_name,
+			DBUS_TYPE_STRING,
+			params->table ? &(params->table) : &empty,
+			DBUS_TYPE_STRING,
+			params->chain ? &(params->chain) : &empty,
+			DBUS_TYPE_STRING,
+			params->target ? &(params->target) : &empty,
+			DBUS_TYPE_STRING,
+			params->ip_src ? &(params->ip_src) : &empty,
+			DBUS_TYPE_STRING,
+			params->ip_dst ? &(params->ip_dst) : &empty,
+			DBUS_TYPE_UINT16, &(params->port_src[0]),
+			DBUS_TYPE_UINT16, &(params->port_src[1]),
+			DBUS_TYPE_UINT16, &(params->port_dst[0]),
+			DBUS_TYPE_UINT16, &(params->port_dst[1]),
+			DBUS_TYPE_STRING,
+			params->protocol ? &(params->protocol) :
+				&empty,
+			DBUS_TYPE_INVALID);
+		break;
+	case ARGS_CLEAR:
+		signal = sailfish_iptables_dbus_signal(
+			SAILFISH_IPTABLES_SIGNAL_CLEAR,
+			DBUS_TYPE_STRING,
+			params->table ? &(params->table) : &empty,
+			DBUS_TYPE_INVALID);
+		break;
+	case ARGS_CLEAR_CHAINS:
+		signal = sailfish_iptables_dbus_signal(
+			SAILFISH_IPTABLES_SIGNAL_CLEAR_CHAINS,
+			DBUS_TYPE_STRING,
+			params->table ? &(params->table) : &empty,
+			DBUS_TYPE_INVALID);
+		break;
+	case ARGS_POLICY:
+		signal = sailfish_iptables_dbus_signal(
+			SAILFISH_IPTABLES_SIGNAL_POLICY,
+			DBUS_TYPE_STRING,
+			params->table ? &(params->table) : &empty,
+			DBUS_TYPE_STRING,
+			params->chain ? &(params->chain) : &empty,
+			DBUS_TYPE_STRING,
+			params->policy ? &(params->policy) : &empty,
+			DBUS_TYPE_INVALID);
+		break;
+	case ARGS_CHAIN:
+		signal = sailfish_iptables_dbus_signal(
+			SAILFISH_IPTABLES_SIGNAL_CHAIN,
+			DBUS_TYPE_STRING,
+			params->table ? &(params->table) : &empty,
+			DBUS_TYPE_STRING,
+			params->chain ? &(params->chain) : &empty,
+			DBUS_TYPE_UINT16, &(params->operation),
+			DBUS_TYPE_INVALID);
+	case ARGS_IP_ICMP:
+	case ARGS_ICMP:
+		switch(params->operation) {
+		case ADD:
+			signal_name =
+				SAILFISH_IPTABLES_SIGNAL_ICMP_ADD;
 			break;
+		case REMOVE:
+			signal_name =
+				SAILFISH_IPTABLES_SIGNAL_ICMP_REM;
+			break;
+		// Rules can be only added or removed
+		default:
+			return NULL;
+		}
+		signal = sailfish_iptables_dbus_signal(
+			signal_name,
+			DBUS_TYPE_STRING,
+			params->table ? &(params->table) : &empty,
+			DBUS_TYPE_STRING,
+			params->chain ? &(params->chain) : &empty,
+			DBUS_TYPE_STRING,
+			params->target ? &(params->target) : &empty,
+			DBUS_TYPE_STRING,
+			params->ip_src ? &(params->ip_src) : &empty,
+			DBUS_TYPE_STRING,
+			params->ip_dst ? &(params->ip_dst) : &empty,
+			DBUS_TYPE_UINT16,
+			&(params->icmp[0]),
+			DBUS_TYPE_UINT16,
+			&(params->icmp[1]),
+			DBUS_TYPE_INVALID);
+		break;
+	default:
+		break;
 	}
 
 	return signal;
@@ -870,156 +903,155 @@ rule_params* sailfish_iptables_dbus_get_parameters_from_msg(
 {
 	rule_params *params = rule_params_new(args);
 	DBusError* error = NULL;
-	
+
 	gchar *ip_src = NULL, *ip_dst = NULL, *target = NULL, *table = NULL;
 	gchar *chain_name = NULL, *custom_chain_name = NULL;
-	gchar *service_dst = NULL, *service_src = NULL, *service_lowercase = NULL;
+	gchar *service_dst = NULL, *service_src = NULL;
+	gchar *service_lowercase = NULL;
 	dbus_uint16_t port_dst[2] = {0};
 	dbus_uint16_t port_src[2] = {0};
 	dbus_uint16_t icmp[2] = {0};
 	dbus_uint16_t operation = 0, policy_int = 0;
 	dbus_uint32_t protocol_int = 0;
 	gint index = 0;
-	
+
 	gboolean rval = false;
-	
-	switch(params->args)
-	{
-		case ARGS_IP:
-			rval = dbus_message_get_args(message, error,
-						DBUS_TYPE_STRING, &table,
-						DBUS_TYPE_STRING, &chain_name,
-						DBUS_TYPE_STRING, &target,
-						DBUS_TYPE_STRING, &ip_src,
-						DBUS_TYPE_STRING, &ip_dst,
-						DBUS_TYPE_UINT16, &operation,
-						DBUS_TYPE_INVALID);
-			break;
-		case ARGS_IP_PORT:
-			rval = dbus_message_get_args(message, error,
-						DBUS_TYPE_STRING, &table,
-						DBUS_TYPE_STRING, &chain_name,
-						DBUS_TYPE_STRING, &target,
-						DBUS_TYPE_STRING, &ip_src,
-						DBUS_TYPE_STRING, &ip_dst,
-						DBUS_TYPE_UINT16, &port_src,
-						DBUS_TYPE_UINT16, &port_dst,
-						DBUS_TYPE_UINT32, &protocol_int,
-						DBUS_TYPE_UINT16, &operation,
-						DBUS_TYPE_INVALID);
-			break;
-		case ARGS_IP_PORT_RANGE:
-			rval = dbus_message_get_args(message, error,
-						DBUS_TYPE_STRING, &table,
-						DBUS_TYPE_STRING, &chain_name,
-						DBUS_TYPE_STRING, &target,
-						DBUS_TYPE_STRING, &ip_src,
-						DBUS_TYPE_STRING, &ip_dst,
-						DBUS_TYPE_UINT16, &(port_src[0]),
-						DBUS_TYPE_UINT16, &(port_src[1]),
-						DBUS_TYPE_UINT16, &(port_dst[0]),
-						DBUS_TYPE_UINT16, &(port_dst[1]),
-						DBUS_TYPE_UINT32, &protocol_int,
-						DBUS_TYPE_UINT16, &operation,
-						DBUS_TYPE_INVALID);
-			break;
-		case ARGS_IP_SERVICE:
-			rval = dbus_message_get_args(message, error,
-						DBUS_TYPE_STRING, &table,
-						DBUS_TYPE_STRING, &chain_name,
-						DBUS_TYPE_STRING, &target,
-						DBUS_TYPE_STRING, &ip_src,
-						DBUS_TYPE_STRING, &ip_dst,
-						DBUS_TYPE_STRING, &service_src,
-						DBUS_TYPE_STRING, &service_dst,
-						DBUS_TYPE_UINT32, &protocol_int,
-						DBUS_TYPE_UINT16, &operation,
-						DBUS_TYPE_INVALID);
-			break;
-		case ARGS_PORT:
-			rval = dbus_message_get_args(message, error,
-						DBUS_TYPE_STRING, &table,
-						DBUS_TYPE_STRING, &chain_name,
-						DBUS_TYPE_STRING, &target,
-						DBUS_TYPE_UINT16, &port_src,
-						DBUS_TYPE_UINT16, &port_dst,
-						DBUS_TYPE_UINT32, &protocol_int,
-						DBUS_TYPE_UINT16, &operation,
-						DBUS_TYPE_INVALID);
-			break;
-		case ARGS_PORT_RANGE:
-			rval = dbus_message_get_args(message, error,
-						DBUS_TYPE_STRING, &table,
-						DBUS_TYPE_STRING, &chain_name,
-						DBUS_TYPE_STRING, &target,
-						DBUS_TYPE_UINT16, &(port_src[0]),
-						DBUS_TYPE_UINT16, &(port_src[1]),
-						DBUS_TYPE_UINT16, &(port_dst[0]),
-						DBUS_TYPE_UINT16, &(port_dst[1]),
-						DBUS_TYPE_UINT32, &protocol_int,
-						DBUS_TYPE_UINT16, &operation,
-						DBUS_TYPE_INVALID);
-			break;
-		case ARGS_SERVICE:
-			rval = dbus_message_get_args(message, error,
-						DBUS_TYPE_STRING, &table,
-						DBUS_TYPE_STRING, &chain_name,
-						DBUS_TYPE_STRING, &target,
-						DBUS_TYPE_STRING, &service_src,
-						DBUS_TYPE_STRING, &service_dst,
-						DBUS_TYPE_UINT32, &protocol_int,
-						DBUS_TYPE_UINT16, &operation,
-						DBUS_TYPE_INVALID);
-			break;
-		case ARGS_CLEAR:
-		case ARGS_CLEAR_CHAINS:
-			rval = dbus_message_get_args(message, error,
-						DBUS_TYPE_STRING, &table,
-						DBUS_TYPE_INVALID);
-			break;
-		case ARGS_POLICY:
-			rval = dbus_message_get_args(message, error,
-						DBUS_TYPE_STRING, &table,
-						DBUS_TYPE_STRING, &chain_name,
-						DBUS_TYPE_UINT16, &policy_int,
-						DBUS_TYPE_INVALID);
-			break;
-		case ARGS_CHAIN:
-			rval = dbus_message_get_args(message, error,
-						DBUS_TYPE_STRING, &table,
-						DBUS_TYPE_STRING, &custom_chain_name,
-						DBUS_TYPE_UINT16, &operation,
-						DBUS_TYPE_INVALID);
-			break;
-		case ARGS_GET_CONTENT:
-			rval = dbus_message_get_args(message, error,
-						DBUS_TYPE_STRING, &table,
-						DBUS_TYPE_INVALID);
-		case ARGS_IP_ICMP:
-		case ARGS_ICMP:
-			rval = dbus_message_get_args(message, error,
-						DBUS_TYPE_STRING, &table,
-						DBUS_TYPE_STRING, &chain_name,
-						DBUS_TYPE_STRING, &target,
-						DBUS_TYPE_STRING, &ip_src,
-						DBUS_TYPE_STRING, &ip_dst,
-						DBUS_TYPE_UINT16, &(icmp[0]),
-						DBUS_TYPE_UINT16, &(icmp[1]),
-						DBUS_TYPE_UINT16, &operation,
-						DBUS_TYPE_INVALID);
-			/*
-			 * IP address is optional with ICMP, if either the
-			 * values is set the value(s) must pass ip check.
-			 * IP check is enabled by changing the type to
-			 * ARGS_IP_ICMP, which is not otherwise enabled.
-			*/
-			if ((ip_src && *ip_src) || (ip_dst && *ip_dst))
-				params->args = ARGS_IP_ICMP;
-			break;
+
+	switch(params->args) {
+	case ARGS_IP:
+		rval = dbus_message_get_args(message, error,
+					DBUS_TYPE_STRING, &table,
+					DBUS_TYPE_STRING, &chain_name,
+					DBUS_TYPE_STRING, &target,
+					DBUS_TYPE_STRING, &ip_src,
+					DBUS_TYPE_STRING, &ip_dst,
+					DBUS_TYPE_UINT16, &operation,
+					DBUS_TYPE_INVALID);
+		break;
+	case ARGS_IP_PORT:
+		rval = dbus_message_get_args(message, error,
+					DBUS_TYPE_STRING, &table,
+					DBUS_TYPE_STRING, &chain_name,
+					DBUS_TYPE_STRING, &target,
+					DBUS_TYPE_STRING, &ip_src,
+					DBUS_TYPE_STRING, &ip_dst,
+					DBUS_TYPE_UINT16, &port_src,
+					DBUS_TYPE_UINT16, &port_dst,
+					DBUS_TYPE_UINT32, &protocol_int,
+					DBUS_TYPE_UINT16, &operation,
+					DBUS_TYPE_INVALID);
+		break;
+	case ARGS_IP_PORT_RANGE:
+		rval = dbus_message_get_args(message, error,
+					DBUS_TYPE_STRING, &table,
+					DBUS_TYPE_STRING, &chain_name,
+					DBUS_TYPE_STRING, &target,
+					DBUS_TYPE_STRING, &ip_src,
+					DBUS_TYPE_STRING, &ip_dst,
+					DBUS_TYPE_UINT16, &(port_src[0]),
+					DBUS_TYPE_UINT16, &(port_src[1]),
+					DBUS_TYPE_UINT16, &(port_dst[0]),
+					DBUS_TYPE_UINT16, &(port_dst[1]),
+					DBUS_TYPE_UINT32, &protocol_int,
+					DBUS_TYPE_UINT16, &operation,
+					DBUS_TYPE_INVALID);
+		break;
+	case ARGS_IP_SERVICE:
+		rval = dbus_message_get_args(message, error,
+					DBUS_TYPE_STRING, &table,
+					DBUS_TYPE_STRING, &chain_name,
+					DBUS_TYPE_STRING, &target,
+					DBUS_TYPE_STRING, &ip_src,
+					DBUS_TYPE_STRING, &ip_dst,
+					DBUS_TYPE_STRING, &service_src,
+					DBUS_TYPE_STRING, &service_dst,
+					DBUS_TYPE_UINT32, &protocol_int,
+					DBUS_TYPE_UINT16, &operation,
+					DBUS_TYPE_INVALID);
+		break;
+	case ARGS_PORT:
+		rval = dbus_message_get_args(message, error,
+					DBUS_TYPE_STRING, &table,
+					DBUS_TYPE_STRING, &chain_name,
+					DBUS_TYPE_STRING, &target,
+					DBUS_TYPE_UINT16, &port_src,
+					DBUS_TYPE_UINT16, &port_dst,
+					DBUS_TYPE_UINT32, &protocol_int,
+					DBUS_TYPE_UINT16, &operation,
+					DBUS_TYPE_INVALID);
+		break;
+	case ARGS_PORT_RANGE:
+		rval = dbus_message_get_args(message, error,
+					DBUS_TYPE_STRING, &table,
+					DBUS_TYPE_STRING, &chain_name,
+					DBUS_TYPE_STRING, &target,
+					DBUS_TYPE_UINT16, &(port_src[0]),
+					DBUS_TYPE_UINT16, &(port_src[1]),
+					DBUS_TYPE_UINT16, &(port_dst[0]),
+					DBUS_TYPE_UINT16, &(port_dst[1]),
+					DBUS_TYPE_UINT32, &protocol_int,
+					DBUS_TYPE_UINT16, &operation,
+					DBUS_TYPE_INVALID);
+		break;
+	case ARGS_SERVICE:
+		rval = dbus_message_get_args(message, error,
+					DBUS_TYPE_STRING, &table,
+					DBUS_TYPE_STRING, &chain_name,
+					DBUS_TYPE_STRING, &target,
+					DBUS_TYPE_STRING, &service_src,
+					DBUS_TYPE_STRING, &service_dst,
+					DBUS_TYPE_UINT32, &protocol_int,
+					DBUS_TYPE_UINT16, &operation,
+					DBUS_TYPE_INVALID);
+		break;
+	case ARGS_CLEAR:
+	case ARGS_CLEAR_CHAINS:
+		rval = dbus_message_get_args(message, error,
+					DBUS_TYPE_STRING, &table,
+					DBUS_TYPE_INVALID);
+		break;
+	case ARGS_POLICY:
+		rval = dbus_message_get_args(message, error,
+					DBUS_TYPE_STRING, &table,
+					DBUS_TYPE_STRING, &chain_name,
+					DBUS_TYPE_UINT16, &policy_int,
+					DBUS_TYPE_INVALID);
+		break;
+	case ARGS_CHAIN:
+		rval = dbus_message_get_args(message, error,
+					DBUS_TYPE_STRING, &table,
+					DBUS_TYPE_STRING, &custom_chain_name,
+					DBUS_TYPE_UINT16, &operation,
+					DBUS_TYPE_INVALID);
+		break;
+	case ARGS_GET_CONTENT:
+		rval = dbus_message_get_args(message, error,
+					DBUS_TYPE_STRING, &table,
+					DBUS_TYPE_INVALID);
+	case ARGS_IP_ICMP:
+	case ARGS_ICMP:
+		rval = dbus_message_get_args(message, error,
+					DBUS_TYPE_STRING, &table,
+					DBUS_TYPE_STRING, &chain_name,
+					DBUS_TYPE_STRING, &target,
+					DBUS_TYPE_STRING, &ip_src,
+					DBUS_TYPE_STRING, &ip_dst,
+					DBUS_TYPE_UINT16, &(icmp[0]),
+					DBUS_TYPE_UINT16, &(icmp[1]),
+					DBUS_TYPE_UINT16, &operation,
+					DBUS_TYPE_INVALID);
+		/*
+		 * IP address is optional with ICMP, if either the
+		 * values is set the value(s) must pass ip check.
+		 * IP check is enabled by changing the type to
+		 * ARGS_IP_ICMP, which is not otherwise enabled.
+		*/
+		if ((ip_src && *ip_src) || (ip_dst && *ip_dst))
+			params->args = ARGS_IP_ICMP;
+		break;
 	}
-	
-	if(error)
-	{
+
+	if(error) {
 		DBG("%s %s %s %s", PLUGIN_NAME, "Error,",
 			!rval ? "Could not get args from dbus message" : "",
 			error->message);
@@ -1030,90 +1062,82 @@ rule_params* sailfish_iptables_dbus_get_parameters_from_msg(
 
 	// Source IP (iptables -s)
 	if(ip_src && g_utf8_validate(ip_src,-1,NULL) &&
-		validate_ip_address(IPV4, ip_src))
-	{
-		if(negated_ip_address(ip_src))
-		{
+		validate_ip_address(IPV4, ip_src)) {
+		if(negated_ip_address(ip_src)) {
 			params->ip_src = format_ip(IPV4, &(ip_src[1]));
 			params->ip_negate_src = true;
-		}
-		else
+		} else
 			params->ip_src = format_ip(IPV4, ip_src);
 	}
 
 	// Destination IP (iptables -d)
 	if(ip_dst && g_utf8_validate(ip_dst,-1,NULL) &&
-		validate_ip_address(IPV4,ip_dst))
-	{
-		if(negated_ip_address(ip_dst))
-		{
+		validate_ip_address(IPV4,ip_dst)) {
+		if(negated_ip_address(ip_dst)) {
 			params->ip_dst = format_ip(IPV4, &(ip_dst[1]));
 			params->ip_negate_dst = true;
-		}
-		else
+		} else
 			params->ip_dst = format_ip(IPV4,ip_dst);
 	}
-	
+
 	// Protocol number set (proto = 0, not supported, see /etc/protocols)
 	// G_MAXUINT32 = all
 	if(protocol_int)
 		params->protocol = validate_protocol_int(protocol_int);
-	
+
 	// Service destination defined
-	if(service_dst && *service_dst && g_utf8_validate(service_dst,-1,NULL))
-	{
+	if(service_dst && *service_dst &&
+					g_utf8_validate(service_dst,-1,NULL)) {
 		service_lowercase = g_utf8_strdown(service_dst,-1);
-		
+
 		// Check if the service with given name can be found, port and
 		// protocol can be retrieved then also
-		if((params->port_dst[0] = validate_service_name(service_lowercase)))
-		{
-			params->service_dst	= service_lowercase;
-			
-			if(!params->protocol)
-				params->protocol = get_protocol_for_service(params->service_dst);
-		}
-	}
-	
-	// Service source defined
-	if(service_src && *service_src && g_utf8_validate(service_src,-1,NULL))
-	{
-		service_lowercase = g_utf8_strdown(service_src,-1);
-		
-		// Check if the service with given name can be found, port and
-		// protocol can be retrieved then also
-		if((params->port_src[0] = validate_service_name(service_lowercase)))
-		{
-			params->service_src	= service_lowercase;
-			
+		if((params->port_dst[0] =
+				validate_service_name(service_lowercase))) {
+			params->service_dst = service_lowercase;
+
 			if(!params->protocol)
 				params->protocol = get_protocol_for_service(
-										params->service_src);
+							params->service_dst);
 		}
 	}
-	
+
+	// Service source defined
+	if(service_src && *service_src &&
+					g_utf8_validate(service_src,-1,NULL)) {
+		service_lowercase = g_utf8_strdown(service_src,-1);
+
+		// Check if the service with given name can be found, port and
+		// protocol can be retrieved then also
+		if((params->port_src[0] = validate_service_name(
+						service_lowercase))) {
+			params->service_src = service_lowercase;
+
+			if(!params->protocol)
+				params->protocol = get_protocol_for_service(
+							params->service_src);
+		}
+	}
+
 	// Check both ports
-	for(index = 0; index < 2 ; index++)
-	{
-		if(port_dst[index] && validate_port(port_dst[index]))
-		{
+	for(index = 0; index < 2 ; index++) {
+		if(port_dst[index] && validate_port(port_dst[index])) {
 			params->port_dst[index] = port_dst[index];
 
 			if(!params->protocol)
 				params->protocol = get_protocol_for_port(
-										params->port_dst[index]);
+						params->port_dst[index]);
 		}
-		
-		if(port_src[index] && validate_port(port_src[index]))
-		{
+
+		if(port_src[index] && validate_port(port_src[index])) {
 			params->port_src[index] = port_src[index];
 
 			if(!params->protocol)
 				params->protocol = get_protocol_for_port(
-										params->port_src[index]);
+						params->port_src[index]);
 		}
 	}
-	
+
 	// Check icmp type and code
 	if (validate_icmp(IPV4, icmp)) {
 		params->icmp[0] = icmp[0];
@@ -1123,44 +1147,44 @@ rule_params* sailfish_iptables_dbus_get_parameters_from_msg(
 	// Operation is always set, if operation is UNDEFINED check_parameters()
 	// will return INVALID_REQUEST
 	params->operation = validate_operation(operation);
-	
-	// For now always default to "filter" table (SAILFISH_IPTABLES_TABLE_NAME)
+
+	// For now always default to "filter" table
+	// (SAILFISH_IPTABLES_TABLE_NAME)
 	if(table && *table && g_utf8_validate(table,-1,NULL))
 		params->table = g_strdup(SAILFISH_IPTABLES_TABLE_NAME);
 		//params->table = g_utf8_strdown(table,-1);
 	else
 		params->table = g_strdup(SAILFISH_IPTABLES_TABLE_NAME);
-	
+
 	if(policy_int)
 		params->policy = validate_policy_int(policy_int);
-	
+
 	// Chain from a iptables rule
 	if(chain_name && *chain_name && g_utf8_validate(chain_name,-1, NULL))
 		params->chain = validate_chain(params->table, chain_name);
-	
+
 	// User specified chain change
-	if(custom_chain_name && *custom_chain_name && 
+	if(custom_chain_name && *custom_chain_name &&
 		g_utf8_validate(custom_chain_name,-1, NULL))
-		params->chain = g_strdup_printf("%s%s", 
+		params->chain = g_strdup_printf("%s%s",
 			SAILFISH_IPTABLES_CHAIN_PREFIX, custom_chain_name);
-			
-	// Target, validate_target() 
+
+	// Target, validate_target()
 	if(target && *target && g_utf8_validate(target, -1, NULL))
 		params->target = validate_target(params->table, target);
-	
+
 	return params;
 }
 
 gint sailfish_iptables_dbus_register(api_data *data) {
-	
+
 	gint rval = 0;
-	
+
 	if(!data)
 		data = api_data_new();
-	
+
 	DBusConnection* conn = connman_dbus_get_connection();
-	if(conn)
-	{
+	if(conn) {
 		if(g_dbus_register_interface(conn,
 			SAILFISH_IPTABLES_DBUS_PATH,
 			SAILFISH_IPTABLES_DBUS_INTERFACE,
@@ -1168,27 +1192,26 @@ gint sailfish_iptables_dbus_register(api_data *data) {
 			signals,
 			NULL,
 			data,
-			(GDBusDestroyFunction)api_data_free))
-		{
-			
+			(GDBusDestroyFunction)api_data_free)) {
+
 			DBusMessage *signal = sailfish_iptables_dbus_signal(
 					SAILFISH_IPTABLES_SIGNAL_INIT,
 					DBUS_TYPE_INVALID, NULL);
-				
+
 			if(signal) // Send to all
-				sailfish_iptables_dbus_send_signal(signal, NULL);
+				sailfish_iptables_dbus_send_signal(signal,
+					NULL);
 		}
-		else
-		{
-			DBG("%s %s %s", PLUGIN_NAME, "sailfish_iptables_dbus_register():",
+		else {
+			DBG("%s %s", PLUGIN_NAME,
+				"sailfish_iptables_dbus_register(): "
 				"register failed");
 			rval = 1;
 		}
 		dbus_connection_unref(conn);
 	}
-	else
-	{
-		DBG("%s %s %s", PLUGIN_NAME, "sailfish_iptables_dbus_register():",
+	else {
+		DBG("%s %s", PLUGIN_NAME, "sailfish_iptables_dbus_register(): "
 			"no dbus connection");
 		rval = 1;
 	}
@@ -1203,32 +1226,31 @@ gint sailfish_iptables_dbus_unregister()
 	gint rval = 0;
 
 	DBusConnection* conn = connman_dbus_get_connection();
-	if(conn)
-	{
+	if(conn) {
 		// First send the signal to all
 		DBusMessage *signal = sailfish_iptables_dbus_signal(
 					SAILFISH_IPTABLES_SIGNAL_STOP,
 					DBUS_TYPE_INVALID, NULL);
 		if(signal)
 			sailfish_iptables_dbus_send_signal(signal, NULL);
-			
+
 		if(!g_dbus_unregister_interface(conn,
 			SAILFISH_IPTABLES_DBUS_PATH,
-			SAILFISH_IPTABLES_DBUS_INTERFACE))
-		{
-			DBG("%s %s %s", PLUGIN_NAME, "sailfish_iptables_dbus_unregister():",
-				"unregsiter failed");
+			SAILFISH_IPTABLES_DBUS_INTERFACE)) {
+			DBG("%s %s", PLUGIN_NAME,
+				"sailfish_iptables_dbus_unregister(): "
+				"unregister failed");
 			rval = 1;
 		}
 		dbus_connection_unref(conn);
 	}
-	else 
+	else
 	{
-		DBG("%s %s","sailfish_iptables_dbus_unregister():",
+		DBG("%s","sailfish_iptables_dbus_unregister(): "
 			"no dbus connection");
 		rval = 1;
 	}
-	
+
 	DBG("sailfish_iptables_dbus_unregister()");
 	return rval;
 }

--- a/src/sailfish-iptables-parameters.c
+++ b/src/sailfish-iptables-parameters.c
@@ -3,25 +3,25 @@
  *  Sailfish Connection Manager iptables plugin parameter handling functions.
  *
  *  BSD 3-Clause License
- * 
+ *
  *  Copyright (c) 2017-2018, Jolla Ltd.
  *  Contact: Jussi Laakkonen <jussi.laakkonen@jolla.com>
  *  All rights reserved.
-
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- * 
+ *
  *  Redistributions of source code must retain the above copyright notice, this
  *  list of conditions and the following disclaimer.
- * 
+ *
  *  Redistributions in binary form must reproduce the above copyright notice,
  *  this list of conditions and the following disclaimer in the documentation
  *  and/or other materials provided with the distribution.
- * 
+ *
  *  Neither the name of the copyright holder nor the names of its
  *  contributors may be used to endorse or promote products derived from
  *  this software without specific prior written permission.
-
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -34,7 +34,7 @@
  *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  */
- 
+
 #define CONNMAN_API_SUBJECT_TO_CHANGE
 
 #include <sys/types.h>
@@ -56,34 +56,35 @@
 void custom_chain_remove(void *data, void *table)
 {
 	gint error = 0;
-	
+
 	gchar *chain = (gchar*)data;
 	gchar *table_name = (gchar*)table;
-	
+
 	if(!chain || !(*chain) || !table_name || !(*table_name))
 		return;
-		
-	DBG("%s %s %s %s %s", PLUGIN_NAME, "custom_chain_remove() flushing", chain,
-		"from table", table_name);
-		
+
+	DBG("%s %s %s %s %s", PLUGIN_NAME, "custom_chain_remove() flushing",
+		chain, "from table", table_name);
+
 	error = connman_iptables_flush_chain(table_name, chain);
-		
+
 	if(error)
-		ERR("%s %s %s %s %s", PLUGIN_NAME, "custom_chain_remove() flushing",
-			chain, " failed from table", table_name);
-	
-	DBG("%s %s %s %s %s", PLUGIN_NAME, "custom_chain_remove() removing", chain,
-		"from table", table_name);
-	
+		ERR("%s %s %s %s %s", PLUGIN_NAME,
+			"custom_chain_remove() flushing", chain,
+			" failed from table", table_name);
+
+	DBG("%s %s %s %s %s", PLUGIN_NAME, "custom_chain_remove() removing",
+		chain, "from table", table_name);
+
 	error = connman_iptables_delete_chain(table_name, chain);
-	
+
 	if(!error)
 		error = connman_iptables_commit(table_name);
 	else
 		DBG("%s %s %s %s %s %s %d", PLUGIN_NAME,
 			"custom_chain_remove() failed to remove chain", chain,
 			"from table", table_name, "error code", error);
-			
+
 	g_free(data);
 }
 
@@ -91,12 +92,12 @@ custom_chain_item* custom_chain_item_new(const gchar* table)
 {
 	if(!table || !(*table))
 		return NULL;
-		
+
 	custom_chain_item* item = g_new0(custom_chain_item,1);
-	
+
 	item->table = g_strdup(table);
 	item->chains = NULL;
-	
+
 	return item;
 }
 
@@ -104,11 +105,11 @@ void custom_chain_item_free(custom_chain_item *item)
 {
 	if(!item)
 		return;
-		
+
 	g_list_foreach(item->chains, custom_chain_remove, item->table);
 	g_list_free(item->chains);
 	g_free(item->table);
-	
+
 	g_free(item);
 }
 
@@ -122,23 +123,21 @@ gboolean custom_chain_item_remove_from_chains(custom_chain_item *item,
 {
 	GList* iter = NULL;
 	gint chains_count = 0;
-	
+
 	if(!item || !chain || !(*chain))
 		return false;
-	
+
 	chains_count = g_list_length(item->chains);
-	
-	for(iter = g_list_first(item->chains); iter; iter = iter->next)
-	{
-		if(!g_ascii_strcasecmp(chain, (gchar*)iter->data))
-		{
+
+	for(iter = g_list_first(item->chains); iter; iter = iter->next) {
+		if(!g_ascii_strcasecmp(chain, (gchar*)iter->data)) {
 			item->chains = g_list_remove_link(item->chains, iter);
 			g_free(iter->data);
 			g_list_free_1(iter);
 			break;
 		}
 	}
-	
+
 	return chains_count - 1 == g_list_length(item->chains) ? true : false;
 }
 
@@ -146,35 +145,32 @@ gboolean custom_chain_item_add_to_chains(custom_chain_item* item,
 	const gchar* chain)
 {
 	gint chains_count = 0;
-	
+
 	if(!item || !chain || !(*chain))
 		return false;
-		
+
 	chains_count = g_list_length(item->chains);
-	
+
 	item->chains = g_list_prepend(item->chains, g_strdup(chain));
-	
+
 	return chains_count + 1 == g_list_length(item->chains) ? true : false;
 }
 
 void dbus_client_free(dbus_client *client)
 {
-	if(client)
-	{
+	if(client) {
 		DBusConnection *conn = connman_dbus_get_connection();
-		
-		if(client->watch_id && conn)
-		{
+
+		if(client->watch_id && conn) {
 			g_dbus_remove_watch(conn, client->watch_id);
 			dbus_connection_unref(conn);
 		}
-		
-		if(client->peer)
-		{
+
+		if(client->peer) {
 			da_peer_unref(client->peer);
 			client->peer = NULL;
 		}
-	
+
 		g_free(client);
 	}
 }
@@ -187,24 +183,23 @@ void dbus_client_free1(void *data)
 dbus_client* dbus_client_new()
 {
 	dbus_client *client = g_new0(dbus_client,1);
-	
+
 	client->watch_id = 0;
 	client->peer = NULL;
-	
+
 	return client;
 }
 
 void api_data_free(api_data *data)
 {
-	if(data)
-	{
+	if(data) {
 		sailfish_iptables_policy_uninitialize(data);
 		g_hash_table_destroy(data->clients);
 		data->clients = NULL;
-		
+
 		g_list_free_full(data->custom_chains, custom_chain_item_free1);
 		data->custom_chains = NULL;
-		
+
 		g_free(data);
 	}
 }
@@ -212,24 +207,24 @@ void api_data_free(api_data *data)
 api_data* api_data_new()
 {
 	api_data *data = g_new0(api_data,1);
-	
+
 	data->clients = g_hash_table_new_full(g_str_hash, g_str_equal, NULL,
 		dbus_client_free1);
-	
+
 	data->custom_chains = NULL;
-		
+
 	data->policy = NULL;
-	
+
 	sailfish_iptables_policy_initialize(data);
-	
+
 	return data;
 }
 
 dbus_client* api_data_get_peer(api_data* data, const gchar* peer_name)
 {
-	if(data && peer_name && *peer_name)
-	{
-		dbus_client *client = g_hash_table_lookup(data->clients, peer_name);
+	if(data && peer_name && *peer_name) {
+		dbus_client *client = g_hash_table_lookup(data->clients,
+						peer_name);
 		return client;
 	}
 	return NULL;
@@ -237,29 +232,27 @@ dbus_client* api_data_get_peer(api_data* data, const gchar* peer_name)
 
 gboolean api_data_add_peer(api_data *data, dbus_client *client)
 {
-	if(data && client && client->peer && client->peer->name)
-	{
-		if(!g_hash_table_replace(data->clients, (gpointer)client->peer->name,
-				client))
-		{
-			DBG("%s %s %s",PLUGIN_NAME,"Cannot add client to db, name: ",
+	if(data && client && client->peer && client->peer->name) {
+		if(!g_hash_table_replace(data->clients,
+			(gpointer)client->peer->name, client)) {
+			DBG("%s %s %s",PLUGIN_NAME,
+				"Cannot add client to db, name: ",
 				client->peer->name);
 			return false;
 		}
 		return true;
-	}	
+	}
 	return false;
 }
 
 gboolean api_data_remove_peer(api_data *data, const gchar *peer_name)
 {
 	gboolean rval = false;
-	if(data && peer_name && *peer_name)
-	{
+	if(data && peer_name && *peer_name) {
 		rval = g_hash_table_remove(data->clients, peer_name);
-		
+
 		if(!rval)
-			DBG("%s %s %s", PLUGIN_NAME, 
+			DBG("%s %s %s", PLUGIN_NAME,
 				"Unable to remove client from db, name:",
 				peer_name);
 	}
@@ -269,19 +262,19 @@ gboolean api_data_remove_peer(api_data *data, const gchar *peer_name)
 GList *api_data_get_custom_chain_table(api_data *data, const gchar* table_name)
 {
 	GList* iter = NULL;
-	
-	if(!data || !table_name || !(*table_name) || 
+
+	if(!data || !table_name || !(*table_name) ||
 		!g_list_length(data->custom_chains))
 		return NULL;
-		
-	for(iter = g_list_first(data->custom_chains); iter ; iter = iter->next)
-	{
+
+	for(iter = g_list_first(data->custom_chains); iter ; iter = iter->next) {
 		custom_chain_item *item = (custom_chain_item*)iter->data;
-		if(item && item->table && *(item->table) && 
-			!g_ascii_strcasecmp(item->table, table_name))
-		{
-			DBG("%s get_custom_chain_table() found table %s chains size %d",
-				PLUGIN_NAME, item->table, g_list_length(item->chains));
+		if(item && item->table && *(item->table) &&
+			!g_ascii_strcasecmp(item->table, table_name)) {
+			DBG("%s get_custom_chain_table() found table %s "
+					"chains size %d",
+				PLUGIN_NAME, item->table,
+				g_list_length(item->chains));
 			return iter;
 		}
 	}
@@ -292,31 +285,30 @@ gboolean api_data_remove_custom_chains(api_data *data, const gchar* table_name)
 {
 	if(!data || !table_name || !(*table_name))
 		return false;
-		
+
 	GList *table_entry = api_data_get_custom_chain_table(data, table_name);
-	
-	if(table_entry)
-	{
-		DBG("%s api_data_remove_custom_chains() remove chains from table %s",
-			PLUGIN_NAME, table_name);
-		
+
+	if(table_entry) {
+		DBG("%s api_data_remove_custom_chains() remove chains from "
+			"table %s", PLUGIN_NAME, table_name);
+
 		custom_chain_item *item = (custom_chain_item*)table_entry->data;
-		
+
 		custom_chain_item_free(item);
-		
+
 		data->custom_chains = g_list_remove_link(data->custom_chains,
 								table_entry);
 		g_list_free_1(table_entry);
-		
+
 		return true;
 	}
 	DBG("%s api_data_remove_custom_chains() no entry found for %s",
 		PLUGIN_NAME, table_name);
-	
+
 	// List is not empty, invalid table name
 	if(g_list_length(data->custom_chains))
 		return false;
-	
+
 	// List empty, nothing done, request ok.
 	return true;
 }
@@ -326,26 +318,25 @@ gboolean api_data_add_custom_chain(api_data *data, const gchar* table_name,
 {
 	if(!data || !table_name || !(*table_name) || !chain || !(*chain))
 		return false;
-		
+
 	GList *table_entry = api_data_get_custom_chain_table(data, table_name);
 	custom_chain_item *item = NULL;
-	
+
 	// Not found, create new
-	if(!table_entry)
-	{
+	if(!table_entry) {
 		item = custom_chain_item_new(table_name);
 		data->custom_chains = g_list_append(data->custom_chains, item);
-		
+
 		DBG("%s api_data_add_custom_chain() creating new table %s",
 			PLUGIN_NAME, item->table);
 	}
-	else
-	{
+	else {
 		item = (custom_chain_item*)table_entry->data;
-		DBG("%s api_data_add_custom_chain() adding to existing table %s (%d)",
-			PLUGIN_NAME, item->table, g_list_length(item->chains));
+		DBG("%s api_data_add_custom_chain() adding to existing table "
+			"%s (%d)", PLUGIN_NAME, item->table,
+			g_list_length(item->chains));
 	}
-	
+
 	return custom_chain_item_add_to_chains(item, chain);
 }
 
@@ -354,24 +345,23 @@ gboolean api_data_delete_custom_chain(api_data *data, const gchar* table_name,
 {
 	if(!data || !table_name || !(*table_name) || !chain || !(*chain))
 		return false;
-	
+
 	if(!data->custom_chains)
 		return false;
-		
+
 	GList *table_entry = api_data_get_custom_chain_table(data, table_name);
-	
-	if(!table_entry)
-	{
-		DBG("%s api_data_delete_custom_chain() no table %s", PLUGIN_NAME,
-			table_name);
+
+	if(!table_entry) {
+		DBG("%s api_data_delete_custom_chain() no table %s",
+			PLUGIN_NAME, table_name);
 		return false;
 	}
-		
+
 	custom_chain_item *item = (custom_chain_item*)table_entry->data;
-	
+
 	DBG("%s api_data_delete_custom_chain() %s from %s", PLUGIN_NAME, chain,
 		table_name);
-		
+
 	return custom_chain_item_remove_from_chains(item, chain);
 }
 
@@ -380,15 +370,16 @@ client_disconnect_data* client_disconnect_data_new(api_data* data,
 {
 	if(!data || !client || !client->peer || !client->peer->name)
 		return NULL;
-		
-	client_disconnect_data* disconnect_data = g_new0(client_disconnect_data,1);
+
+	client_disconnect_data* disconnect_data = g_new0(
+						client_disconnect_data, 1);
 	disconnect_data->main_data = data;
-	
+
 	if(client->peer)
 		disconnect_data->client_name = g_strdup(client->peer->name);
 	else
 		disconnect_data->client_name = NULL;
-	
+
 	return disconnect_data;
 }
 
@@ -402,8 +393,7 @@ void client_disconnect_data_free(client_disconnect_data* data)
 
 void rule_params_free(rule_params *params)
 {
-	if(params)
-	{
+	if(params) {
 		g_free(params->ip_src);
 		g_free(params->ip_dst);
 		g_free(params->service_src);
@@ -413,10 +403,10 @@ void rule_params_free(rule_params *params)
 		g_free(params->policy);
 		g_free(params->chain);
 		g_free(params->target);
-		
+
 		if(params->iptables_content)
 			connman_iptables_free_content(params->iptables_content);
-			
+
 		g_free(params);
 	}
 }
@@ -438,13 +428,13 @@ rule_params* rule_params_new(rule_args args)
 gboolean check_operation(rule_params *params)
 {
 	rule_operation upper = FLUSH;
-	
+
 	if(!params)
 		return false;
-	
+
 	if(params->args == ARGS_CHAIN)
-		upper = UNDEFINED;	
-	
+		upper = UNDEFINED;
+
 	return params->operation >= ADD && params->operation < upper;
 }
 
@@ -452,15 +442,15 @@ gboolean check_port_range(rule_params *params)
 {
 	if(!params)
 		return false;
-		
+
 	if(params->port_dst[1] < params->port_dst[0] &&
 		params->port_dst[1] != params->port_dst[0])
 		return false;
-	
+
 	if(params->port_src[1] < params->port_src[0] &&
 		params->port_src[1] != params->port_src[0])
 		return false;
-		
+
 	return true;
 }
 
@@ -480,29 +470,28 @@ gboolean check_ports(rule_params *params)
 	gboolean rval = false;
 	if(!params)
 		return false;
-		
-	switch(params->args)
-	{
-		// src or dst has to be set
-		case ARGS_IP_PORT:
-		case ARGS_IP_SERVICE:
-		case ARGS_PORT:
-		case ARGS_SERVICE:
-			if(params->port_dst[0])
-				rval = true;
-			if(params->port_src[0])
-				rval |= true;
-			return rval;
-		// either dst or src range must be set, or both
-		case ARGS_IP_PORT_RANGE:
-		case ARGS_PORT_RANGE:
-			if(params->port_dst[0] && params->port_dst[1])
-				rval = true;
-			if(params->port_src[0] && params->port_src[1])
-				rval |= true;
-			return rval;
-		default:
-			return false;
+
+	switch(params->args) {
+	// src or dst has to be set
+	case ARGS_IP_PORT:
+	case ARGS_IP_SERVICE:
+	case ARGS_PORT:
+	case ARGS_SERVICE:
+		if(params->port_dst[0])
+			rval = true;
+		if(params->port_src[0])
+			rval |= true;
+		return rval;
+	// either dst or src range must be set, or both
+	case ARGS_IP_PORT_RANGE:
+	case ARGS_PORT_RANGE:
+		if(params->port_dst[0] && params->port_dst[1])
+			rval = true;
+		if(params->port_src[0] && params->port_src[1])
+			rval |= true;
+		return rval;
+	default:
+		return false;
 	}
 }
 
@@ -511,13 +500,13 @@ gboolean check_service(rule_params *params)
 	if(!params)
 		return false;
 
-	switch(params->args)
-	{
-		case ARGS_IP_SERVICE:
-		case ARGS_SERVICE:
-			return params->service_src || params->service_dst ? true : false;
-		default:
-			return false;
+	switch(params->args) {
+	case ARGS_IP_SERVICE:
+	case ARGS_SERVICE:
+		return params->service_src || params->service_dst ?
+			true : false;
+	default:
+		return false;
 	}
 }
 
@@ -528,21 +517,20 @@ gboolean check_icmp(rule_params *params)
 
 gboolean check_chain_restricted(rule_params *params)
 {
-	const gchar const * DEFAULT_CHAINS[] = {
+	const gchar *default_chains[] = {
 		"INPUT",
 		"OUTPUT",
 		"FORWARD",
 		NULL
 	};
-	
+
 	if(!params || !params->chain)
 		return false;
-	
+
 	gint i = 0;
-	
-	for(i = 0; DEFAULT_CHAINS[i]; i++)
-	{
-		if(!g_ascii_strcasecmp(params->chain, DEFAULT_CHAINS[i]))
+
+	for(i = 0; default_chains[i]; i++) {
+		if(!g_ascii_strcasecmp(params->chain, default_chains[i]))
 			return true;
 	}
 	return false;
@@ -552,78 +540,76 @@ api_result check_parameters(rule_params* params)
 {
 	if(!params)
 		return INVALID;
-		
-	if(params->args >= ARGS_IP && params->args <= ARGS_ICMP)
-	{
+
+	if(params->args >= ARGS_IP && params->args <= ARGS_ICMP) {
 		if(!params->table) return INVALID_TABLE;
 		if(!params->chain) return INVALID_CHAIN_NAME;
 		if(!params->target) return INVALID_TARGET;
 	}
-		
-	switch(params->args)
-	{
-		case ARGS_IP:
-			return check_ips(params) ? OK : INVALID_IP;
-		case ARGS_IP_PORT:
-			if(!check_ips(params)) return INVALID_IP;
-			if(!check_ports(params)) return INVALID_PORT;
-			if(!params->protocol) return INVALID_PROTOCOL;
-			if(!check_operation(params)) return INVALID_REQUEST;
-			return OK;
-		case ARGS_IP_PORT_RANGE:
-			if(!check_ips(params)) return INVALID_IP;
-			if(!check_ports(params)) return INVALID_PORT;
-			if(!check_port_range(params)) return INVALID_PORT_RANGE;
-			if(!params->protocol) return INVALID_PROTOCOL;
-			if(!check_operation(params)) return INVALID_REQUEST;
-			return OK;
-		case ARGS_IP_SERVICE:
-			if(!check_ips(params)) return INVALID_IP;
-			if(!check_service(params)) return INVALID_SERVICE;
-			if(!check_ports(params)) return INVALID_SERVICE;
-			if(!params->protocol) return INVALID_PROTOCOL;
-			if(!check_operation(params)) return INVALID_REQUEST;
-			return OK;
-		case ARGS_PORT:
-			if(!check_ports(params)) return INVALID_PORT;
-			if(!params->protocol) return INVALID_PROTOCOL;
-			if(!check_operation(params)) return INVALID_REQUEST;
-			return OK;
-		case ARGS_PORT_RANGE:
-			if(!check_ports(params)) return INVALID_PORT;
-			if(!check_port_range(params)) return INVALID_PORT_RANGE;
-			if(!params->protocol) return INVALID_PROTOCOL;
-			if(!check_operation(params)) return INVALID_REQUEST;
-			return OK;
-		case ARGS_SERVICE:
-			if(!check_service(params)) return INVALID_SERVICE;
-			if(!params->protocol) return INVALID_SERVICE;
-			if(!check_operation(params)) return INVALID_REQUEST;
-			return OK;
-		case ARGS_CLEAR:
-		case ARGS_CLEAR_CHAINS:
-			if(!params->table) return INVALID_REQUEST;
-			return OK;
-		case ARGS_POLICY:
-			if(!params->chain) return INVALID_CHAIN_NAME;
-			if(!params->table) return INVALID_REQUEST;
-			if(!params->policy) return INVALID_POLICY;
-			return OK;
-		case ARGS_CHAIN:
-			if(!params->chain) return INVALID_CHAIN_NAME;
-			if(!params->table) return INVALID_REQUEST;
-			if(!check_operation(params)) return INVALID_REQUEST;
-			return OK;
-		case ARGS_IP_ICMP:
-			if(!check_ips(params)) return INVALID_IP;
-		case ARGS_ICMP:
-			if(!check_icmp(params)) return INVALID_ICMP;
-			if(!check_operation(params)) return INVALID_REQUEST;
-			return OK;
-		case ARGS_GET_CONTENT:
-			return params->table ? OK : INVALID_REQUEST;
-		default:
-			return INVALID;
+
+	switch(params->args) {
+	case ARGS_IP:
+		return check_ips(params) ? OK : INVALID_IP;
+	case ARGS_IP_PORT:
+		if(!check_ips(params)) return INVALID_IP;
+		if(!check_ports(params)) return INVALID_PORT;
+		if(!params->protocol) return INVALID_PROTOCOL;
+		if(!check_operation(params)) return INVALID_REQUEST;
+		return OK;
+	case ARGS_IP_PORT_RANGE:
+		if(!check_ips(params)) return INVALID_IP;
+		if(!check_ports(params)) return INVALID_PORT;
+		if(!check_port_range(params)) return INVALID_PORT_RANGE;
+		if(!params->protocol) return INVALID_PROTOCOL;
+		if(!check_operation(params)) return INVALID_REQUEST;
+		return OK;
+	case ARGS_IP_SERVICE:
+		if(!check_ips(params)) return INVALID_IP;
+		if(!check_service(params)) return INVALID_SERVICE;
+		if(!check_ports(params)) return INVALID_SERVICE;
+		if(!params->protocol) return INVALID_PROTOCOL;
+		if(!check_operation(params)) return INVALID_REQUEST;
+		return OK;
+	case ARGS_PORT:
+		if(!check_ports(params)) return INVALID_PORT;
+		if(!params->protocol) return INVALID_PROTOCOL;
+		if(!check_operation(params)) return INVALID_REQUEST;
+		return OK;
+	case ARGS_PORT_RANGE:
+		if(!check_ports(params)) return INVALID_PORT;
+		if(!check_port_range(params)) return INVALID_PORT_RANGE;
+		if(!params->protocol) return INVALID_PROTOCOL;
+		if(!check_operation(params)) return INVALID_REQUEST;
+		return OK;
+	case ARGS_SERVICE:
+		if(!check_service(params)) return INVALID_SERVICE;
+		if(!params->protocol) return INVALID_SERVICE;
+		if(!check_operation(params)) return INVALID_REQUEST;
+		return OK;
+	case ARGS_CLEAR:
+	case ARGS_CLEAR_CHAINS:
+		if(!params->table) return INVALID_REQUEST;
+		return OK;
+	case ARGS_POLICY:
+		if(!params->chain) return INVALID_CHAIN_NAME;
+		if(!params->table) return INVALID_REQUEST;
+		if(!params->policy) return INVALID_POLICY;
+		return OK;
+	case ARGS_CHAIN:
+		if(!params->chain) return INVALID_CHAIN_NAME;
+		if(!params->table) return INVALID_REQUEST;
+		if(!check_operation(params)) return INVALID_REQUEST;
+		return OK;
+	case ARGS_IP_ICMP:
+		if(!check_ips(params)) return INVALID_IP;
+	case ARGS_ICMP:
+		if(!check_icmp(params)) return INVALID_ICMP;
+		if(!check_operation(params)) return INVALID_REQUEST;
+		return OK;
+	case ARGS_GET_CONTENT:
+		return params->table ? OK : INVALID_REQUEST;
+	default:
+		return INVALID;
 	}
 }
 

--- a/src/sailfish-iptables-policy.c
+++ b/src/sailfish-iptables-policy.c
@@ -3,25 +3,25 @@
  *  Sailfish Connection Manager iptables plugin policy check functions.
  *
  *  BSD 3-Clause License
- * 
+ *
  *  Copyright (c) 2017-2018, Jolla Ltd.
  *  Contact: Jussi Laakkonen <jussi.laakkonen@jolla.com>
  *  All rights reserved.
 
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- * 
+ *
  *  Redistributions of source code must retain the above copyright notice, this
  *  list of conditions and the following disclaimer.
- * 
+ *
  *  Redistributions in binary form must reproduce the above copyright notice,
  *  this list of conditions and the following disclaimer in the documentation
  *  and/or other materials provided with the distribution.
- * 
+ *
  *  Neither the name of the copyright holder nor the names of its
  *  contributors may be used to endorse or promote products derived from
  *  this software without specific prior written permission.
-
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -34,7 +34,7 @@
  *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  */
- 
+
 #define CONNMAN_API_SUBJECT_TO_CHANGE
 
 #define POLICY_PATH 				"/etc/connman"
@@ -72,50 +72,50 @@ gchar* sailfish_iptables_load_policy(const gchar* policyfile)
 	gchar *file = NULL, *file_real = NULL, *contents = NULL;
 	gsize length = 0;
 	GError *error = NULL;
-	
+
 	// Use default file if not defined
 	if(!policyfile || !(*policyfile))
-		file = g_strdup_printf("%s/%s", POLICY_PATH, DEFAULT_POLICY_FILE);
+		file = g_strdup_printf("%s/%s", POLICY_PATH,
+				DEFAULT_POLICY_FILE);
 	else
 		file = g_strdup_printf("%s/%s", POLICY_PATH, policyfile);
-		
+
 	file_real = realpath(file, NULL);
-	
+
 	// If file does not exist, directs outside storage dir, contents is not
 	// available or contents is empty use the default policy
 	if(!file_real || !g_str_has_prefix(file_real, POLICY_PATH) ||
 		!g_str_has_suffix(file_real, POLICY_SUFFIX) ||
 		!g_file_get_contents(file_real, &contents, &length, &error) ||
-		!(*contents))
-	{
+		!(*contents)) {
 		DBG("%s %s policy file unavailable, using default policy",
 			PLUGIN_NAME, "sailfish_iptables_load_policy()");
 		contents = g_strdup(SAILFISH_IPTABLES_DBUS_ACCESS_POLICY);
 	}
-	
+
 	DBG("%s %s Loaded policy from %s", PLUGIN_NAME,
-		"sailfish_iptables_load_policy()", file_real ? file_real : "default:");
-	
+		"sailfish_iptables_load_policy()", file_real ?
+			file_real : "default:");
+
 	g_free(file);
 	g_free(file_real);
-	
+
 	return contents;
 }
 
-gboolean sailfish_iptables_policy_check_peer(api_data* data, DAPeer *peer, 
+gboolean sailfish_iptables_policy_check_peer(api_data* data, DAPeer *peer,
 	dbus_access policy)
 {
-	if(peer && data)
-	{
-		switch(policy)
-		{
-			case SAILFISH_DBUS_ACCESS:
-			case SAILFISH_DBUS_ACCESS_MANAGE:
-			case SAILFISH_DBUS_ACCESS_LISTEN:
-				return da_policy_check(data->policy, &peer->cred, policy,
-						NULL, DA_ACCESS_DENY);
-			default:
-				return false;
+	if(peer && data) {
+		switch(policy) {
+		case SAILFISH_DBUS_ACCESS:
+		case SAILFISH_DBUS_ACCESS_MANAGE:
+		case SAILFISH_DBUS_ACCESS_LISTEN:
+			return da_policy_check(data->policy,
+					&peer->cred, policy, NULL,
+					DA_ACCESS_DENY);
+		default:
+			return false;
 		}
 	}
 	return false;
@@ -123,78 +123,76 @@ gboolean sailfish_iptables_policy_check_peer(api_data* data, DAPeer *peer,
 
 DAPeer* sailfish_iptables_policy_get_peer(DBusMessage *message, api_data *data)
 {
-	if(message && data)
-	{
+	if(message && data) {
 		const gchar* sender = dbus_message_get_sender(message);
 		dbus_client* client = api_data_get_peer(data, sender);
-		
+
 		return client && client->peer ? client->peer :
 			da_peer_get(data->da_bus, sender);
 	}
 	return NULL;
 }
 
-gboolean sailfish_iptables_policy_check(DBusMessage *message, api_data* data, 
+gboolean sailfish_iptables_policy_check(DBusMessage *message, api_data* data,
 	dbus_access policy)
 {
 	DAPeer *peer = sailfish_iptables_policy_get_peer(message, data);
-	
+
 	return sailfish_iptables_policy_check_peer(data, peer, policy);
 }
 
 gboolean sailfish_iptables_policy_check_args(DBusMessage *message,
 	api_data* data, rule_args args)
 {
-	switch(args)
-	{
-		case ARGS_CLEAR:
-			return sailfish_iptables_policy_check(message, data,
-				SAILFISH_DBUS_ACCESS);
-		case ARGS_IP:
-		case ARGS_IP_PORT:
-		case ARGS_IP_PORT_RANGE:
-		case ARGS_IP_SERVICE:
-		case ARGS_IP_ICMP:
-		case ARGS_PORT:
-		case ARGS_PORT_RANGE:
-		case ARGS_SERVICE:
-		case ARGS_POLICY:
-		case ARGS_CHAIN:
-		case ARGS_GET_CONTENT:
-		case ARGS_CLEAR_CHAINS:
-		case ARGS_ICMP:
-			return sailfish_iptables_policy_check(message, data,
-				SAILFISH_DBUS_ACCESS_MANAGE);
-		default:
-			return false;
+	switch(args) {
+	case ARGS_CLEAR:
+		return sailfish_iptables_policy_check(message, data,
+			SAILFISH_DBUS_ACCESS);
+	case ARGS_IP:
+	case ARGS_IP_PORT:
+	case ARGS_IP_PORT_RANGE:
+	case ARGS_IP_SERVICE:
+	case ARGS_IP_ICMP:
+	case ARGS_PORT:
+	case ARGS_PORT_RANGE:
+	case ARGS_SERVICE:
+	case ARGS_POLICY:
+	case ARGS_CHAIN:
+	case ARGS_GET_CONTENT:
+	case ARGS_CLEAR_CHAINS:
+	case ARGS_ICMP:
+		return sailfish_iptables_policy_check(message, data,
+			SAILFISH_DBUS_ACCESS_MANAGE);
+	default:
+		return false;
 	}
 }
 
 void sailfish_iptables_policy_initialize(api_data* data)
 {
-	if(data)
-	{
+	if(data) {
 		// Load from default path
-		gchar* dbus_policy = sailfish_iptables_load_policy(DEFAULT_POLICY_FILE);
-		
+		gchar* dbus_policy = sailfish_iptables_load_policy(
+						DEFAULT_POLICY_FILE);
+
 		data->da_bus = DA_BUS_SYSTEM;
-		data->policy = da_policy_new_full(dbus_policy, 
+		data->policy = da_policy_new_full(dbus_policy,
 			sailfish_iptables_dbus_access_policy_actions);
-			
+
 		if(!data->policy)
-			ERR("%s %s %s %s %s/%s",
-				PLUGIN_NAME, "sailfish_iptables_policy_initialize()",
-				"failed to load D-Bus policy, plugin access is restricted.",
-				"Check policy file at", POLICY_PATH, DEFAULT_POLICY_FILE);
-			
+			ERR("%s %s %s/%s", PLUGIN_NAME,
+				"sailfish_iptables_policy_initialize() "
+				"failed to load D-Bus policy, plugin access "
+				"is restricted. Check policy file at",
+				POLICY_PATH, DEFAULT_POLICY_FILE);
+
 		g_free(dbus_policy);
 	}
 }
 
 void sailfish_iptables_policy_uninitialize(api_data* data)
 {
-	if(data && data->policy)
-	{
+	if(data && data->policy) {
 		da_policy_unref(data->policy);
 		data->policy = NULL;
 	}

--- a/src/sailfish-iptables-utils.c
+++ b/src/sailfish-iptables-utils.c
@@ -48,8 +48,7 @@
 
 gchar* get_protocol_for_service(const gchar *service)
 {
-	if(service && *service)
-	{
+	if(service && *service) {
 		struct servent *s = getservbyname(service, NULL);
 		if(s)
 			return g_strdup(s->s_proto);
@@ -59,11 +58,10 @@ gchar* get_protocol_for_service(const gchar *service)
 
 gchar* get_protocol_for_port(guint16 port)
 {
-	if(port)
-	{
+	if(port) {
 		struct servent *s = getservbyport(htons(port), NULL);
 		if(s)
-			return g_strdup(s->s_proto);	
+			return g_strdup(s->s_proto);
 	}
 	return NULL;
 }
@@ -72,36 +70,34 @@ guint32 mask_to_cidr(gint type, const gchar* mask_address)
 {
 	gint index = 0, b = 0;
 	guint32 mask = 0, bits = 0;
-	gint i = (type == IPV6 ? IPV6_MASK_MAX : IPV4_MASK_MAX);	
-	
+	gint i = (type == IPV6 ? IPV6_MASK_MAX : IPV4_MASK_MAX);
+
 	gchar **ip_tokens = NULL;
-	
+
 	if(!mask_address)
 		return G_MAXUINT32;
-	
+
 	ip_tokens = g_strsplit(mask_address,IPV4_DELIM,IPV4_TOKENS);
-	
-	if(ip_tokens)
-	{
+
+	if(ip_tokens) {
 		// Mask was given as cidr
-		if(g_strv_length(ip_tokens) == 1)
-		{
-			mask = ((guint32)g_ascii_strtoull(ip_tokens[0],NULL,10));
+		if(g_strv_length(ip_tokens) == 1) {
+			mask = ((guint32)g_ascii_strtoull(ip_tokens[0], NULL,
+				10));
 		}
 		// Dot notation
-		else if(g_strv_length(ip_tokens) == 4)
-		{
+		else if(g_strv_length(ip_tokens) == 4) {
 			for(index = 0; index < 4 && ip_tokens[index]; index++)
 			{
 				b = 24 - 8 * index; // 24,16,8,0
 				mask += ((guint32)g_ascii_strtoull(
-							ip_tokens[index],NULL,10)) << b;
+					ip_tokens[index], NULL, 10)) << b;
 			}
 		}
 	}
-	
+
 	g_strfreev(ip_tokens);
-	
+
 	// Return protocol mask max (32/128)
 	if (mask == G_MAXUINT32)
 		return i;
@@ -112,9 +108,8 @@ guint32 mask_to_cidr(gint type, const gchar* mask_address)
 
 	// Value between protocol max and 2^32, calculate cidr mask
 	bits = G_MAXUINT32 - 1;
-	
-	/* Create cidr notation (bitmask for nw mask) by decrementing 
-	*/
+
+	// Create cidr notation (bitmask for nw mask) by decrementing 
 	while(--i >= 0 && mask != bits)
 		bits <<= 1;
 
@@ -122,35 +117,37 @@ guint32 mask_to_cidr(gint type, const gchar* mask_address)
 }
 
 gchar* format_ip(gint type, const gchar* ip)
-{	
+{
 	gchar *formatted_ip = NULL;
 	gchar **ip_and_mask = NULL;
 	gint mask_max = 0;
-	
+
 	if(!ip || !*ip)
 		return NULL;
-		
+
 	mask_max = (type == IPV6 ? IPV6_MASK_MAX : IPV4_MASK_MAX);
-		
+
 	ip_and_mask = g_strsplit(ip,IP_MASK_DELIM,2);
 
-	if(ip_and_mask && g_strv_length(ip_and_mask) == 2)
-	{
+	if(ip_and_mask && g_strv_length(ip_and_mask) == 2) {
 		guint32 mask = mask_to_cidr(type, ip_and_mask[1]);
-	
-		/* 	TODO: when a IP (not network) is given with a bitmask iptables
-			command changes the IP address to network, thus this cannot be
-			removed using the API as such rule does not exist in iptables -
-			the new one with network does.
+
+		/*
+		 * TODO: when a IP (not network) is given with a bitmask
+		 * iptables command changes the IP address to network, thus
+		 * this cannot be removed using the API as such rule does not
+		 * exist in iptables the new one with network does.
 		*/
-		
+
 		// Proper mask, between 0 and 32/128
 		if(mask && mask < mask_max)
 			formatted_ip = g_strdup_printf("%s/%u",
 				ip_and_mask[0], mask);
 
-		/* 	Iptables command removes /32 (or /128 IPv6) from the end, we do the
-			same, also for 0, TODO: if 0 given iptables sets 0.0.0.0/0 (any)
+		/*
+		 * Iptables command removes /32 (or /128 IPv6) from the end, we
+		 * do the same, also for 0, TODO: if 0 given iptables sets
+		 * 0.0.0.0/0 (any)
 		*/
 		else if((mask && mask == mask_max) || !mask)
 			formatted_ip = g_strdup_printf("%s", ip_and_mask[0]);
@@ -164,9 +161,9 @@ gchar* format_ip(gint type, const gchar* ip)
 		formatted_ip = g_strdup(ip);
 
 	g_strfreev(ip_and_mask);
-	
+
 	return formatted_ip;
-	
+
 }
 
 /*

--- a/src/sailfish-iptables-validate.c
+++ b/src/sailfish-iptables-validate.c
@@ -3,25 +3,25 @@
  *  Sailfish Connection Manager iptables plugin validation functions.
  *
  *  BSD 3-Clause License
- * 
+ *
  *  Copyright (c) 2017-2018, Jolla Ltd.
  *  Contact: Jussi Laakkonen <jussi.laakkonen@jolla.com>
  *  All rights reserved.
-
+ *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- * 
+ *
  *  Redistributions of source code must retain the above copyright notice, this
  *  list of conditions and the following disclaimer.
- * 
+ *
  *  Redistributions in binary form must reproduce the above copyright notice,
  *  this list of conditions and the following disclaimer in the documentation
  *  and/or other materials provided with the distribution.
- * 
+ *
  *  Neither the name of the copyright holder nor the names of its
  *  contributors may be used to endorse or promote products derived from
  *  this software without specific prior written permission.
-
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -34,7 +34,7 @@
  *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  */
- 
+
 #define CONNMAN_API_SUBJECT_TO_CHANGE
 
 #include <sys/types.h>
@@ -63,36 +63,28 @@ gboolean check_ip_address_format(gint type, const gchar* address)
 	gchar** tokens = NULL;
 	gboolean rval = true;
 	gint length = 0, i = 0;
-	
+
 	if(!address && !*address)
 		return false;
-		
+
 	tokens = g_strsplit_set(address,
 		(type == IPV6 ? IPV6_DELIM : IPV4_DELIM),-1);
 	length = g_strv_length(tokens);
-		
-	if(type == IPV6)
-	{	
+
+	if(type == IPV6) {
 		// IPv6 can be just "::"
 		if(!tokens || length < 1 || length > IPV6_TOKENS)
 			rval = false;
-	}
-	// IPv4 as default
-	else
-	{
-		if(tokens && length == IPV4_TOKENS)
-		{
+	} else { // IPv4 as default
+		if(tokens && length == IPV4_TOKENS) {
 			// Check for leading zeroes
-			for(i = 0; i < length; i++)
-			{
-				if(strlen(tokens[i]) > 1 && tokens[i][0] == '0')
-				{
+			for(i = 0; i < length; i++) {
+				if(strlen(tokens[i]) > 1 && tokens[i][0] == '0') {
 					rval = false;
 					goto out;
 				}
 			}
-		}
-		else
+		} else
 			rval = false;
 	}
 out:
@@ -105,22 +97,19 @@ gboolean validate_address(gint type, const gchar* address)
 {
 	struct addrinfo hints;
 	struct addrinfo *result = NULL;
-	
+
 	// Address must be at least 1.1.1.1, or IPv4 mapped (::ffff:0.0.0.0)
-	if(address && *address && 
+	if(address && *address &&
 		check_ip_address_length(type, address) &&
-		check_ip_address_format(type, address))
-	{		
+		check_ip_address_format(type, address)) {
 		memset(&hints, 0, sizeof(struct addrinfo));
 
 		hints.ai_family = (type == IPV6 ? AF_INET6 : AF_INET);
 		hints.ai_flags = AI_NUMERICHOST;
 
 		// Success
-		if(!getaddrinfo(address,NULL,&hints,&result))
-		{
-			if(result)
-			{
+		if(!getaddrinfo(address,NULL,&hints,&result)) {
+			if(result) {
 				freeaddrinfo(result);
 				return true;
 			}
@@ -132,9 +121,8 @@ gboolean validate_address(gint type, const gchar* address)
 gboolean validate_ip_mask(gint type, const gchar* mask)
 {
 	guint32 int_mask = 0;
-	
-	if(type == IPV4 && mask && *mask)
-	{
+
+	if(type == IPV4 && mask && *mask) {
 		// Dot notation mask
 		if(strchr(mask,'.'))
 			int_mask = mask_to_cidr(type, mask);
@@ -146,35 +134,34 @@ gboolean validate_ip_mask(gint type, const gchar* mask)
 			int_mask != G_MAXUINT32)
 			return true;
 	}
-	
+
 	return false;
 }
 
 gboolean validate_ip_address(gint type, const gchar* ip)
 {
 	gboolean rval = false;
-	
-	if(ip && *ip)
-	{
+
+	if(ip && *ip) {
 		const gchar *address = NULL;
 		gchar **ip_and_mask = NULL;
-		
+
 		// Allow negation
 		if(negated_ip_address(ip))
 			address = &ip[1];
 		else
 			address = ip;
-			
+
 		// Check for mask
 		ip_and_mask = g_strsplit(address,IP_MASK_DELIM,2);
-		
+
 		// Both IP and mask are defined
 		if(ip_and_mask && g_strv_length(ip_and_mask) == 2)
-		 	rval = validate_address(type,ip_and_mask[0]) &&
-		 			validate_ip_mask(type, ip_and_mask[1]);
+			rval = validate_address(type,ip_and_mask[0]) &&
+					validate_ip_mask(type, ip_and_mask[1]);
 		else
 			rval = address && validate_address(type, address);
-		
+
 		g_strfreev(ip_and_mask);
 	}
 	return rval;
@@ -182,19 +169,17 @@ gboolean validate_ip_address(gint type, const gchar* ip)
 
 guint16 validate_service_name(const gchar *service)
 {
-	if(service && *service)
-	{	
+	if(service && *service) {
 		struct servent *s = getservbyname(service, NULL);
 		if(s)
-			return ntohs(s->s_port);	
+			return ntohs(s->s_port);
 	}
 	return 0;
 }
 
 gboolean validate_protocol(const gchar *protocol)
 {
-	if(protocol && *protocol)
-	{
+	if(protocol && *protocol) {
 		struct protoent *p = getprotobyname(protocol);
 		if(p)
 			return true;
@@ -205,28 +190,26 @@ gboolean validate_protocol(const gchar *protocol)
 gchar* validate_protocol_int(gint protocol)
 {
 	gchar *proto_str = NULL;
-	
+
 	/* TODO add support for other protocols too via getprotobynumber(). */
-	switch(protocol)
-	{
-		case IPPROTO_TCP:
-			return g_strdup("tcp");
-		case IPPROTO_UDP:
-			return g_strdup("udp");
-		default:
-			return NULL;
+	switch(protocol) {
+	case IPPROTO_TCP:
+		return g_strdup("tcp");
+	case IPPROTO_UDP:
+		return g_strdup("udp");
+	default:
+		return NULL;
 	}
-	
-	/*if(protocol && protocol != G_MAXUINT32)
-	{
+
+	/*if(protocol && protocol != G_MAXUINT32) {
 		struct protoent *p = getprotobynumber(protocol);
-		
+
 		if(p)
 			proto_str = g_utf8_strdown(p->p_name, -1);
 	}
 	else if(protocol == G_MAXUINT32)
 		proto_str = g_strdup("all");*/
-	
+
 	return proto_str;
 }
 
@@ -237,14 +220,13 @@ gboolean validate_port(guint16 port)
 
 gboolean validate_icmp(int protocol, guint16 *icmp)
 {
-	switch (protocol)
-	{
-		case IPV4:
-		case AF_INET:
-			return icmp[0] < 0x2c && icmp[1] < 0x10;
-		case IPV6:
-		case AF_INET6:
-			return icmp[0] < 0xa2 && icmp[1] < 0x100;
+	switch (protocol) {
+	case IPV4:
+	case AF_INET:
+		return icmp[0] < 0x2c && icmp[1] < 0x10;
+	case IPV6:
+	case AF_INET6:
+		return icmp[0] < 0xa2 && icmp[1] < 0x100;
 	}
 
 	return false;
@@ -252,16 +234,15 @@ gboolean validate_icmp(int protocol, guint16 *icmp)
 
 rule_operation validate_operation(guint16 operation)
 {
-	switch(operation)
-	{
-		case ADD:
-			return ADD;
-		case REMOVE:
-			return REMOVE;
-		case FLUSH:
-			return FLUSH;
-		default:
-			return UNDEFINED;
+	switch(operation) {
+	case ADD:
+		return ADD;
+	case REMOVE:
+		return REMOVE;
+	case FLUSH:
+		return FLUSH;
+	default:
+		return UNDEFINED;
 	}
 }
 
@@ -269,42 +250,42 @@ gchar *validate_chain(const gchar *table, const gchar *chain)
 {
 	gint i = 0;
 	gchar *custom_chain = NULL;
-	
+
 	if(!table || !(*table) || !chain || !(*chain))
 		return NULL;
-	
-	const gchar const * DEFAULT_CHAINS[] = {
+
+	const gchar *default_chains[] = {
 		"INPUT",
 		"OUTPUT",
 		"FORWARD",
 		NULL
 	};
-	
-	for(i = 0; DEFAULT_CHAINS[i]; i++)
-	{
-		if(!g_ascii_strcasecmp(chain,DEFAULT_CHAINS[i]))
+
+	for(i = 0; default_chains[i]; i++) {
+		if(!g_ascii_strcasecmp(chain, default_chains[i]))
 			return g_utf8_strup(chain, -1); // return a copy
 	}
-	
+
 	// Prefix chain
 	custom_chain = g_strdup_printf("%s%s",
 		SAILFISH_IPTABLES_CHAIN_PREFIX, chain);
-	
-	// Find chain with prefixed target name, table can be NULL and results in
-	// -EINVAL but check_parameters() will return INVALID_TABLE in such case
-	switch(connman_iptables_find_chain(table, custom_chain))
-	{
-		case 0:
-			return custom_chain; // Return formatted chain that is prefixed
-		// TODO add DBG to these
-		case -1:
-		case -EINVAL:
-		default:
-			break;
+
+	// Find chain with prefixed target name, table can be NULL and results
+	// in -EINVAL but check_parameters() will return INVALID_TABLE in such
+	// case
+	switch(connman_iptables_find_chain(table, custom_chain)) {
+	case 0:
+		// Return formatted chain that is prefixed
+		return custom_chain;
+	// TODO add DBG to these
+	case -1:
+	case -EINVAL:
+	default:
+		break;
 	}
-	
+
 	g_free(custom_chain);
-	
+
 	return NULL;
 }
 
@@ -312,12 +293,12 @@ gchar* validate_target(const gchar *table, const gchar *target)
 {
 	gint i = 0;
 	gchar *chain = NULL;
-	
+
 	if(!table || !(*table) || !target || !(*target))
 		return NULL;
-	
+
 	// Add sailfish builtin targets here
-	const gchar const * ALLOWED_TARGETS[] = {
+	const gchar *allowed_targets[] = {
 		"ACCEPT",
 		"DROP",
 		"QUEUE",
@@ -325,53 +306,50 @@ gchar* validate_target(const gchar *table, const gchar *target)
 		"REJECT",
 		NULL
 	};
-	
-	const gchar const * DENIED_TARGETS[] = {
+
+	const gchar *denied_targets[] = {
 		"INPUT",
 		"OUTPUT",
 		"FORWARD",
 		NULL
 	};
-	
+
 	// One of the builtin targets
-	for(i = 0; ALLOWED_TARGETS[i]; i++)
-	{
-		if(!g_ascii_strcasecmp(target, ALLOWED_TARGETS[i]))
+	for(i = 0; allowed_targets[i]; i++) {
+		if(!g_ascii_strcasecmp(target, allowed_targets[i]))
 			return g_utf8_strup(target, -1); // Return a copy
 	}
-	
+
 	// If one of the bultin chains
-	for(i = 0; DENIED_TARGETS[i]; i++)
-	{
-		if(!g_ascii_strcasecmp(target, ALLOWED_TARGETS[i]))
+	for(i = 0; denied_targets[i]; i++) {
+		if(!g_ascii_strcasecmp(target, allowed_targets[i]))
 			return NULL; // Return null, this is invalid target
 	}
-	
+
 	// Prefix chain
 	chain = g_strdup_printf("%s%s",	SAILFISH_IPTABLES_CHAIN_PREFIX, target);
-	
-	// Find chain with prefixed target name, table can be NULL and results in
-	// -EINVAL but check_parameters() will return INVALID_TABLE in such case
-	switch(connman_iptables_find_chain(table, chain))
-	{
-		case 0:
-			return chain; // Return formatted chain that is prefixed
-		// TODO add DBG to these
-		case -1:
-		case -EINVAL:
-		default:
-			break;
+
+	// Find chain with prefixed target name, table can be NULL and results
+	// in -EINVAL but check_parameters() will return INVALID_TABLE in such
+	// case
+	switch(connman_iptables_find_chain(table, chain)) {
+	case 0:
+		return chain; // Return formatted chain that is prefixed
+	// TODO add DBG to these
+	case -1:
+	case -EINVAL:
+	default:
+		break;
 	}
-	
+
 	g_free(chain);
-	
+
 	return NULL;
 }
 
 gboolean validate_policy(const gchar* policy)
 {
-	if(policy && *policy)
-	{
+	if(policy && *policy) {
 		if(!g_strcmp0(policy,IPTABLES_ACCEPT) ||
 			!g_strcmp0(policy,IPTABLES_DROP))
 			return true;
@@ -381,14 +359,13 @@ gboolean validate_policy(const gchar* policy)
 
 gchar* validate_policy_int(guint16 policy_int)
 {
-	switch(policy_int)
-	{
-		case IPTABLES_ACCEPT_INT:
-			return g_strdup(IPTABLES_ACCEPT);
-		case IPTABLES_DROP_INT:
-			return g_strdup(IPTABLES_DROP);
-		default:
-			return NULL;
+	switch(policy_int) {
+	case IPTABLES_ACCEPT_INT:
+		return g_strdup(IPTABLES_ACCEPT);
+	case IPTABLES_DROP_INT:
+		return g_strdup(IPTABLES_DROP);
+	default:
+		return NULL;
 	}
 }
 

--- a/src/sailfish-iptables.c
+++ b/src/sailfish-iptables.c
@@ -3,25 +3,25 @@
  *  Sailfish Connection Manager iptables plugin
  *
  *  BSD 3-Clause License
- * 
+ *
  *  Copyright (c) 2017-2018, Jolla Ltd.
  *  Contact: Jussi Laakkonen <jussi.laakkonen@jolla.com>
  *  All rights reserved.
 
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
- * 
+ *
  *  Redistributions of source code must retain the above copyright notice, this
  *  list of conditions and the following disclaimer.
- * 
+ *
  *  Redistributions in binary form must reproduce the above copyright notice,
  *  this list of conditions and the following disclaimer in the documentation
  *  and/or other materials provided with the distribution.
- * 
+ *
  *  Neither the name of the copyright holder nor the names of its
  *  contributors may be used to endorse or promote products derived from
  *  this software without specific prior written permission.
-
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -58,27 +58,27 @@
 api_result clear_iptables_rules(rule_params* params, api_data *data)
 {
 	api_result rval = INVALID;
-	
+
 	if((rval = check_parameters(params)) != OK)
 		return rval;
-		
+
 	DBG("%s %s %s", PLUGIN_NAME, "CLEAR table", params->table);
-	
+
 	if(!connman_iptables_clear(params->table))
 		rval = OK;
-		
+
 	return rval;
 }
 
 api_result clear_iptables_chains(rule_params* params, api_data *data)
 {
 	api_result rval = INVALID;
-	
+
 	if((rval = check_parameters(params)) != OK)
 		return rval;
-		
+
 	DBG("%s %s %s", PLUGIN_NAME, "CLEAR table chains", params->table);
-	
+
 	if(api_data_remove_custom_chains(data, params->table))
 		rval = OK;
 
@@ -88,13 +88,14 @@ api_result clear_iptables_chains(rule_params* params, api_data *data)
 api_result get_iptables_content(rule_params* params, api_data *data)
 {
 	api_result rval = INVALID;
-	
+
 	if((rval = check_parameters(params)) != OK)
 		return rval;
-		
-	if((params->iptables_content = connman_iptables_get_content(params->table)))
+
+	if((params->iptables_content = connman_iptables_get_content(
+						params->table)))
 		rval = OK;
-	
+
 	return rval;
 }
 
@@ -102,22 +103,20 @@ api_result set_policy(rule_params* params, api_data *data)
 {
 	gint error = 0;
 	api_result rval = INVALID;
-	
-	if((rval = check_parameters(params)) == OK)
-	{
+
+	if((rval = check_parameters(params)) == OK) {
 		if(!(error = connman_iptables_change_policy(
-					SAILFISH_IPTABLES_TABLE_NAME, params->chain,
-					params->policy)))
-		{
-			if(!(error = connman_iptables_commit(SAILFISH_IPTABLES_TABLE_NAME)))
-			{
+				SAILFISH_IPTABLES_TABLE_NAME,
+				params->chain, params->policy))) {
+			if(!(error = connman_iptables_commit(
+					SAILFISH_IPTABLES_TABLE_NAME))) {
 				rval = OK;
-				
-				DBG("%s %s %s %s", PLUGIN_NAME, "set_policy(): changed policy", 
+
+				DBG("%s %s %s %s", PLUGIN_NAME,
+					"set_policy(): changed policy",
 					params->chain, params->policy);
 			}
-		}
-		else
+		} else
 			rval = INVALID_POLICY;
 	}
 
@@ -125,264 +124,265 @@ api_result set_policy(rule_params* params, api_data *data)
 }
 
 api_result add_rule_to_iptables(rule_params *params, api_data *data)
-{	
+{
 	api_result rval = INVALID;
 	gint error = 0;
 	GString *rule = NULL;
 	gchar* str_rule = NULL;
 	const gchar* ipt_operation = NULL;
-	
+
 	if((rval = check_parameters(params)) != OK)
 		return rval;
 
 	ipt_operation = params->chain;
-		
+
 	rule = g_string_new("");
-	
+
 	// Generate rule
-	
-	switch(params->args)
-	{
-		case ARGS_PORT:
-		case ARGS_SERVICE:
-		case ARGS_PORT_RANGE:
-			g_string_append_printf(rule,"-p %s -m %s",
-				params->protocol, params->protocol);
-					
-			if(params->port_src[0])
-			{
-				if(params->port_src[1]) // Range specified
-					g_string_append_printf(rule," --sport %u:%u",
-						params->port_src[0], params->port_src[1]);
-				else
-					g_string_append_printf(rule," --sport %u",
-						params->port_src[0]);
-			}
-			
-			if(params->port_dst[0])
-			{
-				if(params->port_dst[1]) // Range specified
-					g_string_append_printf(rule," --dport %u:%u",
-					params->port_dst[0], params->port_dst[1]);
-				else
-					g_string_append_printf(rule," --dport %u",
-						params->port_dst[0]);
-			}
 
-			break;
-		case ARGS_IP:
-		case ARGS_IP_PORT:
-		case ARGS_IP_SERVICE:
-		case ARGS_IP_PORT_RANGE:
-			if(params->ip_src)
-				g_string_append_printf(rule,"-s%s%s", 
-					params->ip_negate_src ? " ! " : " ", params->ip_src);
-			
-			if(params->ip_dst)
-				g_string_append_printf(rule," -d%s%s",
-					params->ip_negate_dst ? " ! " : " ", params->ip_dst);
-			
-			if(params->args == ARGS_IP) // Has no more parameters
-				break;
-			
-			g_string_append_printf(rule," -p %s -m %s",
-				params->protocol, params->protocol);
-			
-			if(params->port_src[0])
-			{
-				if(params->port_src[1]) // Range specified
-					g_string_append_printf(rule," --sport %u:%u",
-						params->port_src[0], params->port_src[1]);
-				else
-					g_string_append_printf(rule," --sport %u",
-						params->port_src[0]);
-			}
-			
-			if(params->port_dst[0])
-			{
-				if(params->port_dst[1]) // Range specified
-					g_string_append_printf(rule," --dport %u:%u",
-					params->port_dst[0], params->port_dst[1]);
-				else
-					g_string_append_printf(rule," --dport %u",
-						params->port_dst[0]);
-			}
-
-			break;
-		case ARGS_IP_ICMP:
-			if(params->ip_src)
-				g_string_append_printf(rule,"-s%s%s",
-					params->ip_negate_src ? " ! " : " ",
-					params->ip_src);
-
-			if(params->ip_dst)
-				g_string_append_printf(rule," -d%s%s",
-					params->ip_negate_dst ? " ! " : " ",
-					params->ip_dst);
-		case ARGS_ICMP:
-			g_string_append_printf(rule, " -p icmp -m icmp"
-					" --icmp-type %u/%u", params->icmp[0],
-					params->icmp[1]);
-
-			break;
-		default:
-			rval = INVALID_REQUEST;
-			break;
-	}
-	
-	g_string_append_printf(rule," -j %s", params->target);
+	switch(params->args) {
+	case ARGS_PORT:
+	case ARGS_SERVICE:
+	case ARGS_PORT_RANGE:
+		g_string_append_printf(rule,"-p %s -m %s",
+			params->protocol, params->protocol);
 		
+		if(params->port_src[0]) {
+			if(params->port_src[1]) // Range specified
+				g_string_append_printf(rule," --sport %u:%u",
+					params->port_src[0],
+					params->port_src[1]);
+			else
+				g_string_append_printf(rule," --sport %u",
+					params->port_src[0]);
+		}
+
+		if(params->port_dst[0]) {
+			if(params->port_dst[1]) // Range specified
+				g_string_append_printf(rule," --dport %u:%u",
+				params->port_dst[0], params->port_dst[1]);
+			else
+				g_string_append_printf(rule," --dport %u",
+					params->port_dst[0]);
+		}
+
+		break;
+	case ARGS_IP:
+	case ARGS_IP_PORT:
+	case ARGS_IP_SERVICE:
+	case ARGS_IP_PORT_RANGE:
+		if(params->ip_src)
+			g_string_append_printf(rule,"-s%s%s",
+				params->ip_negate_src ? " ! " : " ",
+				params->ip_src);
+
+		if(params->ip_dst)
+			g_string_append_printf(rule," -d%s%s",
+				params->ip_negate_dst ? " ! " : " ",
+				params->ip_dst);
+
+		if(params->args == ARGS_IP) // Has no more parameters
+			break;
+
+		g_string_append_printf(rule," -p %s -m %s",
+			params->protocol, params->protocol);
+
+		if(params->port_src[0]) {
+			if(params->port_src[1]) // Range specified
+				g_string_append_printf(rule," --sport %u:%u",
+					params->port_src[0],
+					params->port_src[1]);
+			else
+				g_string_append_printf(rule," --sport %u",
+					params->port_src[0]);
+		}
+
+		if(params->port_dst[0]) {
+			if(params->port_dst[1]) // Range specified
+				g_string_append_printf(rule," --dport %u:%u",
+				params->port_dst[0], params->port_dst[1]);
+			else
+				g_string_append_printf(rule," --dport %u",
+					params->port_dst[0]);
+		}
+
+		break;
+	case ARGS_IP_ICMP:
+		if(params->ip_src)
+			g_string_append_printf(rule,"-s%s%s",
+				params->ip_negate_src ? " ! " : " ",
+				params->ip_src);
+
+		if(params->ip_dst)
+			g_string_append_printf(rule," -d%s%s",
+				params->ip_negate_dst ? " ! " : " ",
+				params->ip_dst);
+	case ARGS_ICMP:
+		g_string_append_printf(rule, " -p icmp -m icmp"
+				" --icmp-type %u/%u", params->icmp[0],
+				params->icmp[1]);
+
+		break;
+	default:
+		rval = INVALID_REQUEST;
+		break;
+	}
+
+	g_string_append_printf(rule," -j %s", params->target);
+
 	if(rval != OK)
 		goto param_error;
 
 	str_rule = g_string_free(rule,FALSE);
-	
-	if(str_rule && params->operation != UNDEFINED)
-	{
-		if(params->operation == ADD)
-		{	
-			if(!(error = connman_iptables_append(SAILFISH_IPTABLES_TABLE_NAME,
-				ipt_operation, str_rule)))
-				DBG("%s %s %s %s", PLUGIN_NAME, "connman_iptables_append",
+
+	if(str_rule && params->operation != UNDEFINED) {
+		if(params->operation == ADD) {
+			if(!(error = connman_iptables_append(
+				SAILFISH_IPTABLES_TABLE_NAME, ipt_operation,
+				str_rule)))
+				DBG("%s %s %s %s", PLUGIN_NAME,
+					"connman_iptables_append",
 					ipt_operation, str_rule);
 			else
 				ERR("%s %s %s %s  %d", PLUGIN_NAME,
-					"connman_iptables_append failure", ipt_operation, str_rule,
-					error);
+					"connman_iptables_append failure",
+					ipt_operation, str_rule, error);
 		}
-		else if(params->operation == REMOVE)
-		{
-			if(!(error = connman_iptables_delete(SAILFISH_IPTABLES_TABLE_NAME, 
-				ipt_operation, str_rule)))
+		else if(params->operation == REMOVE) {
+			if(!(error = connman_iptables_delete(
+				SAILFISH_IPTABLES_TABLE_NAME, ipt_operation,
+				str_rule)))
 				DBG("%s %s %s %s", PLUGIN_NAME,
-					"connman_iptables_delete success", ipt_operation, str_rule);
+					"connman_iptables_delete success",
+					ipt_operation, str_rule);
 			else
 				ERR("%s %s %s %s %d", PLUGIN_NAME,
-					"connman_iptables_delete failure", ipt_operation, str_rule,
-					error);
+					"connman_iptables_delete failure",
+					ipt_operation, str_rule, error);
 		}
-	
-		if(!error)
-		{
-			if(!(error = connman_iptables_commit(SAILFISH_IPTABLES_TABLE_NAME)))
-				DBG("%s %s %d", PLUGIN_NAME, "connman_iptables_commit", error);
-			else
-			{
-				ERR("%s %s %d", PLUGIN_NAME, "connman_iptables_commit failed:",
+
+		if(!error) {
+			if(!(error = connman_iptables_commit(
+				SAILFISH_IPTABLES_TABLE_NAME)))
+				DBG("%s %s %d", PLUGIN_NAME,
+					"connman_iptables_commit", error);
+			else {
+				ERR("%s %s %d", PLUGIN_NAME,
+					"connman_iptables_commit failed:",
 					error);
-				
-				// If commit had errors, try to remove added rule
-				if(params->operation == ADD)
-				{
-					if(!connman_iptables_delete(SAILFISH_IPTABLES_TABLE_NAME, 
+
+				// If commit had errors, try to remove new rule
+				if(params->operation == ADD) {
+					if(!connman_iptables_delete(
+						SAILFISH_IPTABLES_TABLE_NAME,
 						ipt_operation, str_rule))
-						DBG("%s %s %s", PLUGIN_NAME, 
-							"connman_iptables_delete reverted", str_rule);
+						DBG("%s %s %s", PLUGIN_NAME,
+							"connman_iptables_delete "
+							"reverted", str_rule);
 					else
-						ERR("%s %s %s", PLUGIN_NAME, 
-							"Cannot revert rule, restart connman. Rule:",
-							str_rule);
+						ERR("%s %s %s", PLUGIN_NAME,
+							"Cannot revert rule, "
+							"restart connman. "
+							"Rule:", str_rule);
 				}
-				
+
 				rval = INVALID;
 			}
 		}
-		else
-		{
+		else {
 			if(params->operation == REMOVE)
 				rval = RULE_DOES_NOT_EXIST;
 			else
 				rval = INVALID_REQUEST;
 		}
 	}
-	
+
 	g_free(str_rule);
-	
+
 	return params->operation == UNDEFINED ? INVALID_REQUEST : rval;
 
 param_error:
 	g_string_free(rule,true);
-	DBG("%s %s %s %d", PLUGIN_NAME, "add_rule_to_iptables()", 
-		"invalid parameters given, rule is not added, error code", rval);
+	DBG("%s %s %d", PLUGIN_NAME, "add_rule_to_iptables() "
+		"invalid parameters given, rule is not added, error code",
+		rval);
 	return rval;
 }
 
 api_result manage_chain(rule_params* params, api_data *data)
 {
 	gint error = 0;
-	switch(params->operation)
-	{
-		case ADD:
-			DBG("%s Adding chain %s to table %s", PLUGIN_NAME,
-				params->chain, params->table);
-			error = connman_iptables_new_chain(params->table, 
-				params->chain);
-			break;
-		case REMOVE:
-			DBG("%s Flushing chain %s from table %s (pre-removal)",
-				PLUGIN_NAME, params->chain, params->table);
-			error = connman_iptables_flush_chain(params->table,
-				params->chain);
-				
-			if(error)
-			{
-				ERR("%s Flushing chain %s in table %s failed (pre-removal) %s",
-					PLUGIN_NAME, params->chain, params->table,
-					"chain cannot be deleted.");
-				return INVALID; // TODO add iptables error.
-			}
-			
-			DBG("%s Removing chain %s from table %s", PLUGIN_NAME,
-				params->chain, params->table);
-			error = connman_iptables_delete_chain(params->table,
-				params->chain);
-			break;
-		case FLUSH:
-			DBG("%s Flushing chain %s from table %s", PLUGIN_NAME,
-				params->chain, params->table);
-			error = connman_iptables_flush_chain(params->table,
-				params->chain);
-			break;
-		default:
-			return INVALID_REQUEST;
+	switch(params->operation) {
+	case ADD:
+		DBG("%s Adding chain %s to table %s", PLUGIN_NAME,
+			params->chain, params->table);
+		error = connman_iptables_new_chain(params->table,
+			params->chain);
+		break;
+	case REMOVE:
+		DBG("%s Flushing chain %s from table %s (pre-removal)",
+			PLUGIN_NAME, params->chain, params->table);
+		error = connman_iptables_flush_chain(params->table,
+			params->chain);
+
+		if(error) {
+			ERR("%s Flushing chain %s in table %s failed "
+				"(pre-removal) %s", PLUGIN_NAME,
+				params->chain, params->table,
+				"chain cannot be deleted.");
+			return INVALID; // TODO add iptables error.
+		}
+
+		DBG("%s Removing chain %s from table %s", PLUGIN_NAME,
+			params->chain, params->table);
+		error = connman_iptables_delete_chain(params->table,
+			params->chain);
+		break;
+	case FLUSH:
+		DBG("%s Flushing chain %s from table %s", PLUGIN_NAME,
+			params->chain, params->table);
+		error = connman_iptables_flush_chain(params->table,
+			params->chain);
+		break;
+	default:
+		return INVALID_REQUEST;
 	}
-	
-	switch(error)
-	{
-		// Try to commit
-		case 0:
-			if(!(error = connman_iptables_commit(params->table)))
-			{
-				switch(params->operation)
-				{
-					case ADD:
-						api_data_add_custom_chain(data, params->table, 
-							params->chain);
-						break;
-					case REMOVE:
-						api_data_delete_custom_chain(data, params->table, 
-							params->chain);
-						break;
-					default:
-						break;
-				}
-				return OK;
+
+	switch(error) {
+	// Try to commit
+	case 0:
+		if(!(error = connman_iptables_commit(params->table))) {
+			switch(params->operation) {
+			case ADD:
+				api_data_add_custom_chain(data, params->table,
+					params->chain);
+				break;
+			case REMOVE:
+				api_data_delete_custom_chain(data,
+					params->table, params->chain);
+				break;
+			default:
+				break;
 			}
-			// Commit failed, try to remove chain
-			else
-				if(!connman_iptables_delete_chain(params->table,
-					params->chain))
-					ERR("%s %s %s", PLUGIN_NAME,
-						"manage_chain() commit error",
-						"chain could not be removed, please restart connman.");
-			break;
-		case -1:
-			return INVALID_REQUEST;
-		default:
-			break;
+			return OK;
+		}
+		// Commit failed, try to remove chain
+		else
+			if(!connman_iptables_delete_chain(params->table,
+				params->chain))
+				ERR("%s %s", PLUGIN_NAME,
+					"manage_chain() commit error. "
+					"Chain could not be removed, "
+					"please restart connman.");
+		break;
+	case -1:
+		return INVALID_REQUEST;
+	default:
+		break;
 	}
-	
-	ERR("%s %s %d %s %d", PLUGIN_NAME, "manage_chain() failed with operation",
+
+	ERR("%s %s %d %s %d", PLUGIN_NAME,
+		"manage_chain() failed with operation",
 		(gint)params->operation, "Error code: ", error);
 	return INVALID_CHAIN_NAME;
 }
@@ -394,21 +394,21 @@ DBusMessage* process_request(DBusMessage *message,
 	api_result result = INVALID;
 	rule_params *params = NULL;
 	DBusMessage *signal = NULL;
-	
+
 	if(!sailfish_iptables_policy_check_args(message, data, args))
 		result = ACCESS_DENIED;
-	else if((params = sailfish_iptables_dbus_get_parameters_from_msg(message,
-		args)))
-	{	
-		if((result = func(params, data)) == OK)
-		{
-			signal = sailfish_iptables_dbus_signal_from_rule_params(params);
+	else if((params = sailfish_iptables_dbus_get_parameters_from_msg(
+				message, args))) {
+		if((result = func(params, data)) == OK) {
+			signal =
+				sailfish_iptables_dbus_signal_from_rule_params(
+					params);
 			if(signal)
-				sailfish_iptables_dbus_send_signal(signal, data);
-		}
-		else
-			ERR("%s %s %s %d", PLUGIN_NAME,
-				"process_request():",
+				sailfish_iptables_dbus_send_signal(signal,
+					data);
+		} else
+			ERR("%s %s: %d", PLUGIN_NAME,
+				"process_request(): "
 				"request was not successful",
 				result);
 	}
@@ -422,49 +422,50 @@ void setup_custom_chains_from_output(api_data *data)
 
 	connman_iptables_content* content = connman_iptables_get_content(
 		SAILFISH_IPTABLES_TABLE_NAME);
-		
+
 	if(!content)
 		return;
-		
-	for(iter = g_list_first(content->chains); iter ; iter = iter->next)
-	{
+
+	for(iter = g_list_first(content->chains); iter ; iter = iter->next) {
 		gchar *chain = (gchar*)iter->data;
-		
-		if(g_str_has_prefix(chain, SAILFISH_IPTABLES_CHAIN_PREFIX))
-		{
+
+		if(g_str_has_prefix(chain, SAILFISH_IPTABLES_CHAIN_PREFIX)) {
 			gchar **tokens = g_strsplit(chain," ", 2);
-			DBG("setup_custom_chains_from_output() adding %s", tokens[0]);
-			if(api_data_add_custom_chain(data, SAILFISH_IPTABLES_TABLE_NAME,
-				tokens[0]))
-				DBG("setup_custom_chains_from_output() added %s", tokens[0]);
+			DBG("setup_custom_chains_from_output() adding %s",
+				tokens[0]);
+
+			if(api_data_add_custom_chain(data,
+				SAILFISH_IPTABLES_TABLE_NAME, tokens[0]))
+				DBG("setup_custom_chains_from_output() added "
+				"%s", tokens[0]);
 			g_strfreev(tokens);
 		}
 	}
-	
+
 	connman_iptables_free_content(content);
 }
 
 static int sailfish_iptables_init(void)
 {
 	DBG("%s %s", PLUGIN_NAME, "initialize");
-	
+
 	int err = 0;
 	api_data *data = api_data_new();
-		
+
 	setup_custom_chains_from_output(data);
-		
+
 	err = sailfish_iptables_dbus_register(data);
-	
+
 	if(err != 0)
 		DBG("%s %s", PLUGIN_NAME, "Cannot register to D-Bus");
-	
+
 	return 0;
 }
 
 static void sailfish_iptables_exit(void)
 {
 	DBG("%s %s", PLUGIN_NAME, "EXIT IPTABLES API");
-	
+
 	sailfish_iptables_dbus_unregister();
 }
 

--- a/test/ete-test/sailfish-connman-iptables-plugin-test
+++ b/test/ete-test/sailfish-connman-iptables-plugin-test
@@ -8,7 +8,8 @@ REQUIRED_COMMANDS_BASE="dbus-send grep id"
 REQUIRED_COMMANDS_PRIV="$REQUIRED_COMMANDS_BASE"
 REQUIRED_COMMANDS_ROOT="$REQUIRED_COMMANDS_BASE iptables iptables-save iptables-restore"
 
-REQUIRED_USERS="root nemo"
+DEFAULT_USERNAME="defaultuser"
+REQUIRED_USERS="root $DEFAULT_USERNAME"
 REQUIRED_GROUPS="users privileged"
 PRIVILEGED=0
 
@@ -657,7 +658,7 @@ function run_clear_test()
 function run_register_tests()
 {
 	# 1. unregister, 11 for all
-	# 2. register, 0 for root, privileged, 12 for nemo
+	# 2. register, 0 for root, privileged, 12 for defaultuser
 	# 3. unregister, 11 for all since dbus-send quits after send
 	
 	MESSAGES="Unregister Register Unregister"
@@ -740,7 +741,7 @@ function run_tests()
 {
 	USER=$(whoami)
 	case $USER in
-		"nemo" | "sailfish_mdm")
+		"$DEFAULT_USERNAME" | "sailfish_mdm")
 			run_clear_test
 			;;
 	esac
@@ -834,7 +835,7 @@ function set_expected_result()
 	case $USER in
 		"root")
 			;;
-		"nemo" | "sailfish-mdm")
+		"$DEFAULT_USERNAME" | "sailfish-mdm")
 			CLEAR_RESULT=$RESULT_ACCESS_DENIED
 			if [[ $PRIVILEGED -eq 0 ]] ; then
 				METHOD_INPUTS_RESULT=$RESULT_ACCESS_DENIED

--- a/test/save-restore-test/save-restore-test
+++ b/test/save-restore-test/save-restore-test
@@ -81,7 +81,7 @@ EMPTY_IPTABLES[4]=':OUTPUT ACCEPT.*'
 EMPTY_IPTABLES[5]='COMMIT'
 EMPTY_IPTABLES[6]='# Completed on.*'
 
-CONNMAN_SAVE_FILE="/var/lib/connman/iptables/filter.v4"
+CONNMAN_SAVE_FILE="/home/.system/var/lib/connman/iptables/filter.v4"
 
 function include_sources()
 {

--- a/test/test-definition/tests.xml
+++ b/test/test-definition/tests.xml
@@ -9,7 +9,7 @@
 				</step>
 			</case>
 			<case manual="false" name="End-to-end test as privileged user" timeout="150">
-				<step>PATH=/sbin:$PATH /usr/sbin/run-blts-root /bin/su -g privileged -c '/opt/tests/sailfish-connman-iptables-plugin/ete-test/sailfish-connman-iptables-plugin-test' nemo
+				<step>PATH=/sbin:$PATH /usr/sbin/run-blts-root /bin/su -g privileged -c '/opt/tests/sailfish-connman-iptables-plugin/ete-test/sailfish-connman-iptables-plugin-test' defaultuser
 				</step>
 			</case>
 			<case manual="false" name="End-to-end test as regular user" timeout="150">

--- a/unit/test-sailfish-connman-plugin-iptables.c
+++ b/unit/test-sailfish-connman-plugin-iptables.c
@@ -41,7 +41,7 @@ void connman_iptables_free_content(connman_iptables_content *content)
 {
 	if(!content)
 		return;
-		
+
 	g_list_free(content->chains);
 	g_list_free(content->rules);
 	g_free(content->table);
@@ -50,8 +50,7 @@ void connman_iptables_free_content(connman_iptables_content *content)
 
 void da_peer_unref(DAPeer* peer)
 {
-	if(peer)
-	{
+	if(peer) {
 		if(peer->name)
 			g_free((gchar*)peer->name);
 		g_free(peer);
@@ -79,53 +78,53 @@ static void test_iptables_plugin_policy_check_user()
 	gint i = 0;
 	api_data* data = api_data_new();
 	DAPeer* peer = g_new0(DAPeer, 1);
-	
+
 	g_assert(data);
-	
+
 	static const gid_t groups[] = {
 		39, 100, 993, 996, 997, 999, 1000, 1002, 1003, 1004,
 		1005, 1006, 1024, 100000
 	};
-	
+
 	DACred cred = {
 		100000, 100000,
 		groups, G_N_ELEMENTS(groups),
 		0,
 		DBUSACCESS_CRED_CAPS | DBUSACCESS_CRED_GROUPS
 	};
-	
+
 	peer->cred = cred;
-	
+
 	gchar *peer_name = g_strdup(":1.1234");
 	peer->name = g_strdup(peer_name);
-	
+
 	g_assert(!sailfish_iptables_policy_check_peer(data, peer, SAILFISH_DBUS_ACCESS_MANAGE));
 	g_assert(!sailfish_iptables_policy_check_peer(data, peer, SAILFISH_DBUS_ACCESS));
 	g_assert(!sailfish_iptables_policy_check_peer(data, peer, SAILFISH_DBUS_ACCESS_LISTEN));
-	
+
 	g_assert(!sailfish_iptables_policy_check_peer(data, peer, 0));
 	g_assert(!sailfish_iptables_policy_check_peer(data, peer, 100));
-	
+
 	DBusMessage* msg = dbus_message_new_method_call("net.connman",
 		"/org/sailfishos/connman/mdm/iptables",
 		"org.sailfishos.connman.mdm.iptables",
 		"GetVersion");
-		
+
 	dbus_message_set_sender(msg, peer_name);
-	
+
 	dbus_client* client = dbus_client_new();
 	g_assert(client);
-	
+
 	client->peer = peer;
 	g_assert(api_data_add_peer(data, client));
-	
+
 	for(i = 0; i <= ARGS_CHAIN ; i++)
 		g_assert(!sailfish_iptables_policy_check_args(msg, data, i));
-	
+
 	g_assert(!sailfish_iptables_policy_check_args(msg, data, ARGS_CHAIN+1));
-	
+
 	g_assert(api_data_remove_peer(data, peer_name));
-	
+
 	dbus_message_unref(msg);
 	api_data_free(data);
 	g_free(peer_name);
@@ -136,48 +135,48 @@ static void test_iptables_plugin_policy_check_root()
 	gint i = 0;
 	api_data* data = api_data_new();
 	DAPeer* peer = g_new0(DAPeer,1);
-	
+
 	g_assert(data);
-	
+
 	DACred cred = {
 		0, 0,
 		NULL, 0,
 		G_GUINT64_CONSTANT(0xfffffff008003420),
 		DBUSACCESS_CRED_CAPS | DBUSACCESS_CRED_GROUPS
 	};
-	
+
 	peer->cred = cred;
-	
+
 	gchar *peer_name = g_strdup(":1.1234");
 	peer->name = g_strdup(peer_name);
-		
+
 	g_assert(sailfish_iptables_policy_check_peer(data, peer, SAILFISH_DBUS_ACCESS_MANAGE));
 	g_assert(sailfish_iptables_policy_check_peer(data, peer, SAILFISH_DBUS_ACCESS));
 	g_assert(sailfish_iptables_policy_check_peer(data, peer, SAILFISH_DBUS_ACCESS_LISTEN));
-	
+
 	g_assert(!sailfish_iptables_policy_check_peer(data, peer, 0));
 	g_assert(!sailfish_iptables_policy_check_peer(data, peer, SAILFISH_DBUS_ACCESS_LISTEN+1));
-	
+
 	DBusMessage* msg = dbus_message_new_method_call("net.connman",
 		"/org/sailfishos/connman/mdm/iptables",
 		"org.sailfishos.connman.mdm.iptables",
 		"GetVersion");
-		
+
 	dbus_message_set_sender(msg, peer_name);
-	
+
 	dbus_client* client = dbus_client_new();
 	g_assert(client);
-	
+
 	client->peer = peer;
 	g_assert(api_data_add_peer(data, client));
-	
+
 	for(i = 0; i <= ARGS_CHAIN ; i++)
 		g_assert(sailfish_iptables_policy_check_args(msg, data, i));
-	
+
 	g_assert(!sailfish_iptables_policy_check_args(msg, data, ARGS_CHAIN+1));
-	
+
 	g_assert(api_data_remove_peer(data, peer_name));
-	
+
 	dbus_message_unref(msg);
 	api_data_free(data);
 	g_free(peer_name);
@@ -187,29 +186,29 @@ static void test_iptables_plugin_policy_check_basic()
 {
 	gint i = 0;
 	api_data* data = api_data_new();
-	
+
 	g_assert(data);
-	
+
 	for(i = 0; i <= SAILFISH_DBUS_ACCESS_LISTEN ; i++)
 		g_assert(!sailfish_iptables_policy_check_peer(NULL, NULL,i));
-	
+
 	for(i = 0; i <= SAILFISH_DBUS_ACCESS_LISTEN ; i++)
 		g_assert(!sailfish_iptables_policy_check_peer(data, NULL,i));
-	
+
 	g_assert(!sailfish_iptables_policy_get_peer(NULL, NULL));
 	g_assert(!sailfish_iptables_policy_check(NULL, NULL, SAILFISH_DBUS_ACCESS_MANAGE));
 	g_assert(!sailfish_iptables_policy_check_args(NULL, NULL, ARGS_CLEAR));
-	
+
 	DBusMessage* msg = dbus_message_new_method_call("net.connman",
 		"/org/sailfishos/connman/mdm/iptables",
 		"org.sailfishos.connman.mdm.iptables",
 		"GetVersion");
-		
+
 	dbus_message_set_sender(msg,":1.1234");
-	
+
 	g_assert(!sailfish_iptables_policy_get_peer(msg, data));
 	g_assert(!sailfish_iptables_policy_check(msg, data, SAILFISH_DBUS_ACCESS_MANAGE));
-	
+
 	dbus_message_unref(msg);
 	api_data_free(data);
 }
@@ -222,37 +221,37 @@ static void test_iptables_plugin_policy_check_basic()
 static void test_iptables_plugin_policy_load()
 {
 	gchar *policy = NULL;
-	
+
 	policy = sailfish_iptables_load_policy(NULL);
 	g_assert(policy);
 	g_assert(!g_ascii_strcasecmp(policy, DEFAULT_POLICY1));
 	g_free(policy);
-	
+
 	policy = sailfish_iptables_load_policy("");
 	g_assert(policy);
 	g_assert(!g_ascii_strcasecmp(policy, DEFAULT_POLICY1));
 	g_free(policy);
-	
+
 	policy = sailfish_iptables_load_policy("policy.conf");
 	g_assert(policy);
 	g_assert(!g_ascii_strcasecmp(policy, DEFAULT_POLICY1));
 	g_free(policy);
-	
+
 	policy = sailfish_iptables_load_policy("policy");
 	g_assert(policy);
 	g_assert(!g_ascii_strcasecmp(policy, DEFAULT_POLICY1));
 	g_free(policy);
-	
+
 	policy = sailfish_iptables_load_policy("policy.sh");
 	g_assert(policy);
 	g_assert(!g_ascii_strcasecmp(policy, DEFAULT_POLICY1));
 	g_free(policy);
-	
+
 	policy = sailfish_iptables_load_policy("../../policy.conf");
 	g_assert(policy);
 	g_assert(!g_ascii_strcasecmp(policy, DEFAULT_POLICY1));
 	g_free(policy);
-	
+
 	policy = sailfish_iptables_load_policy("iptables_policy.conf");
 	g_assert(policy);
 	g_assert(!g_ascii_strcasecmp(policy, DEFAULT_POLICY1));
@@ -273,7 +272,7 @@ static void test_iptables_plugin_utils_protocol_for_port()
 	gchar* protocol = get_protocol_for_port(22);
 	g_assert(g_ascii_strcasecmp(protocol,"tcp") == 0);
 	g_free(protocol);
-	
+
 	g_assert(!get_protocol_for_port(0));
 }
 
@@ -282,14 +281,13 @@ static void test_iptables_plugin_utils_mask_to_cidr()
 	struct in_addr addr;
 	memset(&addr,0,sizeof(struct in_addr));
 	gint i = 0;
-	
+
 	g_assert(inet_aton("255.255.255.255", &addr));
-	
+
 	// Check all valid masks
-	for(i = 32 ; i >= 0 ; i--)
-	{
+	for(i = 32 ; i >= 0 ; i--) {
 		g_assert(mask_to_cidr(IPV4,inet_ntoa(addr)) == i);
-		
+
 		// Reduce one up bit from mask, 255.255.255.254, 255.255.255.252 etc.
 		in_addr_t addr_int = ntohl(addr.s_addr);
 		addr_int <<= 1;
@@ -310,69 +308,68 @@ static gchar *combine_ip_mask(const gchar* address, guint32 mask)
 	gchar *result = NULL;
 	if(address && *address)
 		result = g_strdup_printf("%s/%u",address,mask);
-		
+
 	return result;
 }
 
 static void test_iptables_plugin_utils_format_ip()
 {
 	gchar* ip = NULL;
-	
+
 	ip = format_ip(IPV4,"192.168.10.1");
 	g_assert(g_ascii_strcasecmp(ip,"192.168.10.1") == 0);
 	g_free(ip);
-	
+
 	// Mask is removed if mask is 32 or 0 in cidr format
 	ip = format_ip(IPV4,"192.168.10.1/32");
 	g_assert(g_ascii_strcasecmp(ip,"192.168.10.1") == 0);
 	g_free(ip);
-	
+
 	ip = format_ip(IPV4,"192.168.10.1/0");
 	g_assert(g_ascii_strcasecmp(ip,"192.168.10.1") == 0);
 	g_free(ip);
-	
+
 	ip = format_ip(IPV4,"192.168.10.1/0.0.0.0");
 	g_assert(g_ascii_strcasecmp(ip,"192.168.10.1") == 0);
 	g_free(ip);
-	
+
 	ip = format_ip(IPV4,"192.168.10.1/255.255.255.255");
 	g_assert(g_ascii_strcasecmp(ip,"192.168.10.1") == 0);
 	g_free(ip);
-	
+
 	// Check all dot notation masks with ip
 	struct in_addr addr;
 	memset(&addr,0,sizeof(struct in_addr));
 	gint i = 0;
-	
+
 	g_assert(inet_aton("255.255.255.254", &addr));
-	
+
 	// Check all valid masks (excluding 32 and 0)
-	for(i = 31 ; i > 0 ; i--)
-	{
+	for(i = 31 ; i > 0 ; i--) {
 		// Create dot notation format
 		gchar *ip_input = g_strjoin("/", "192.168.10.0", inet_ntoa(addr), NULL);
 		// Create ip dot notation / cidr
 		gchar *ip_check = combine_ip_mask("192.168.10.0",i);
-		
+
 		// Check both in dot notation
 		ip = format_ip(IPV4,ip_input);
 		g_assert(g_ascii_strcasecmp(ip,ip_check) == 0);
 		g_free(ip);
-		
+
 		// Check dot notation ip / cidr
 		ip = format_ip(IPV4,ip_check);
 		g_assert(g_ascii_strcasecmp(ip,ip_check) == 0);
 		g_free(ip);
-		
+
 		g_free(ip_input);
 		g_free(ip_check);
-		
+
 		// Reduce one up bit from mask, 255.255.255.254, 255.255.255.252 etc.
 		in_addr_t addr_int = ntohl(addr.s_addr);
 		addr_int <<= 1;
 		addr.s_addr = htonl(addr_int);
 	}
-	
+
 	g_assert(!format_ip(IPV4, ""));
 	g_assert(!format_ip(IPV4, NULL));
 }
@@ -380,15 +377,15 @@ static void test_iptables_plugin_utils_format_ip()
 static void full_parameter_prepare(rule_params *params)
 {
 	g_assert(params);
-		
+
 	g_assert(check_parameters(params) == INVALID_TABLE);
-	
+
 	params->table = g_strdup("table");
 	g_assert(check_parameters(params) == INVALID_CHAIN_NAME);
-	
+
 	params->chain = g_strdup("chain");
 	g_assert(check_parameters(params) == INVALID_TARGET);
-	
+
 	params->target = g_strdup("ACCEPT");
 }
 
@@ -398,23 +395,23 @@ static void test_iptables_plugin_parameters_ip_full()
 	rule_params *params = rule_params_new(ARGS_IP);
 
 	full_parameter_prepare(params);
-	
+
 	g_assert(check_parameters(params) == INVALID_IP);
-	
+
 	params->ip_src = g_strdup("192.168.10.1");
 	g_assert(check_parameters(params) == OK);
-	
+
 	params->ip_dst = g_strdup("192.168.10.1");
 	g_assert(check_parameters(params) == OK);
-	
+
 	g_free(params->ip_src);
 	params->ip_src = NULL;
 	g_assert(check_parameters(params) == OK);
-	
+
 	g_free(params->ip_dst);
 	params->ip_dst = NULL;
 	g_assert(check_parameters(params) == INVALID_IP);
-	
+
 	rule_params_free(params);
 }
 
@@ -423,60 +420,59 @@ static void test_iptables_plugin_parameters_port_full()
 	/* Port only : ARGS_PORT */
 	rule_params *params = rule_params_new(ARGS_PORT);
 	guint16 i = 0;
-	
+
 	full_parameter_prepare(params);
-	
+
 	// Both unset, fail
 	g_assert(check_parameters(params) == INVALID_PORT);
-	
+
 	// Either set, pass to next check (proto)
 	params->port_dst[0] = 80;
 	g_assert(check_parameters(params) == INVALID_PROTOCOL);
-	
+
 	// Both set, pass to next check (proto)
 	params->port_src[0] = 8080;
 	g_assert(check_parameters(params) == INVALID_PROTOCOL);
-	
+
 	// Src set, pass to next check (proto)
 	params->port_dst[0] = 0;
 	g_assert(check_parameters(params) == INVALID_PROTOCOL);
-	
+
 	params->protocol = g_strdup("tcp");
 	g_assert(check_parameters(params) == INVALID_REQUEST);
-	
-	for(i = 0; i < 4 ; i++)
-	{
+
+	for(i = 0; i < 4 ; i++) {
 		params->operation = i;
 		if(i < 2)
 			g_assert(check_parameters(params) == OK);
 		else
 			g_assert(check_parameters(params) == INVALID_REQUEST);
 	}
-	
+
 	params->operation = 0; // add
-	
+
 	params->port_dst[0] = params->port_src[0] = 0; // Reset
-	
+
 	// Both unset, fail
 	g_assert(check_parameters(params) == INVALID_PORT);
-	
+
 	params->port_dst[1] = params->port_src[1] = 443;
-	
+
 	// range ports have no effect
 	g_assert(check_parameters(params) == INVALID_PORT);
-	
+
 	//dst set, pass
 	params->port_dst[0] = 80;
 	g_assert(check_parameters(params) == OK);
-	
+
 	// Both set, pass 
 	params->port_src[0] = 8080;
 	g_assert(check_parameters(params) == OK);
-	
+
 	// Src set, pass 
 	params->port_dst[0] = 0;
 	g_assert(check_parameters(params) == OK);
-	
+
 	rule_params_free(params);
 }
 
@@ -485,109 +481,108 @@ static void test_iptables_plugin_parameters_ip_and_port_full()
 	/* Port and ip  : ARGS_IP_PORT */
 	rule_params *params = rule_params_new(ARGS_IP_PORT);
 	guint16 i = 0;
-	
+
 	full_parameter_prepare(params);
-	
+
 	g_assert(check_parameters(params) == INVALID_IP);
-	
+
 	params->ip_src = g_strdup("192.168.10.1");
 	g_assert(check_parameters(params) == INVALID_PORT);
-	
+
 	params->ip_dst = g_strdup("192.168.10.1");
 	g_assert(check_parameters(params) == INVALID_PORT);
-	
+
 	g_free(params->ip_src);
 	params->ip_src = NULL;
 	g_assert(check_parameters(params) == INVALID_PORT);
-	
+
 	g_free(params->ip_dst);
 	params->ip_dst = NULL;
 	g_assert(check_parameters(params) == INVALID_IP);
-	
+
 	params->ip_src = g_strdup("192.168.10.1");
 	g_assert(check_parameters(params) == INVALID_PORT);
-	
+
 	// Either set, pass to next check (proto)
 	params->port_dst[0] = 80;
 	g_assert(check_parameters(params) == INVALID_PROTOCOL);
-	
+
 	// Both set, pass to next check (proto)
 	params->port_src[0] = 8080;
 	g_assert(check_parameters(params) == INVALID_PROTOCOL);
-	
+
 	// Src set, pass to next check (proto)
 	params->port_dst[0] = 0;
 	g_assert(check_parameters(params) == INVALID_PROTOCOL);
-	
+
 	params->protocol = g_strdup("tcp");
 	g_assert(check_parameters(params) == INVALID_REQUEST);
-	
-	for(i = 0; i < 4 ; i++)
-	{
+
+	for(i = 0; i < 4 ; i++) {
 		params->operation = i;
 		if(i < 2)
 			g_assert(check_parameters(params) == OK);
 		else
 			g_assert(check_parameters(params) == INVALID_REQUEST);
 	}
-	
+
 	params->operation = 0; // add
-	
+
 	// Reset
 	params->port_dst[0] = params->port_src[0] = 0; 
 	g_free(params->ip_src);
 	params->ip_src = NULL;	
 	g_free(params->ip_dst);
 	params->ip_dst = NULL;
-	
+
 	params->ip_src = g_strdup("192.168.10.1");
 	params->port_dst[1] = params->port_src[1] = 443;
-	
+
 	// range ports have no effect
 	g_assert(check_parameters(params) == INVALID_PORT);
-	
+
 	//dst set, pass
 	params->port_dst[0] = 80;
 	g_assert(check_parameters(params) == OK);
-	
+
 	// Both set, pass 
 	params->port_src[0] = 8080;
 	g_assert(check_parameters(params) == OK);
-	
+
 	// Src set, pass 
 	params->port_dst[0] = 0;
 	g_assert(check_parameters(params) == OK);
-	
+
 	// Reset
 	g_free(params->ip_src);
 	params->ip_src = NULL;
 	params->port_dst[0] = params->port_src[0] = 0; 
-	
+
 	params->ip_dst = g_strdup("192.168.10.1");
 	params->port_dst[1] = params->port_src[1] = 443;
-	
+
 	// range ports have no effect
 	g_assert(check_parameters(params) == INVALID_PORT);
-	
+
 	//dst set, pass
 	params->port_dst[0] = 80;
 	g_assert(check_parameters(params) == OK);
-	
+
 	// Both set, pass 
 	params->port_src[0] = 8080;
 	g_assert(check_parameters(params) == OK);
-	
+
 	// Src set, pass 
 	params->port_dst[0] = 0;
 	g_assert(check_parameters(params) == OK);
-	
+
 	rule_params_free(params);
 }
 
 static void reset_params_ips(rule_params *params)
 {
 	g_assert(params);
-		
+
 	g_free(params->ip_src);
 	params->ip_src = NULL;
 	g_free(params->ip_dst);
@@ -603,74 +598,71 @@ static void ip_port_and_range_full_positive(rule_params *params)
 {
 	guint16 i = 0;
 	g_assert(params);
-	
+
 	reset_params_ports(params);
-	
+
 	params->operation = 0;
 
 /* src ports */
 	params->port_src[0] = params->port_src[1] = 8080;
 	g_assert(check_parameters(params) == OK);
-	
+
 	params->port_src[0] = 8081;
 	g_assert(check_parameters(params) == INVALID_PORT_RANGE);
-	
+
 	params->port_src[0] = 80;
 	g_assert(check_parameters(params) == OK);
-	
-	for(i = 0; i < 4 ; i++)
-	{
+
+	for(i = 0; i < 4 ; i++) {
 		params->operation = i;
 		if(i < 2)
 			g_assert(check_parameters(params) == OK);
 		else
 			g_assert(check_parameters(params) == INVALID_REQUEST);
 	}
-	
+
 	reset_params_ports(params);
-	
+
 	params->operation = 0; // add
 
 /* dst ports */
 	params->port_dst[0] = params->port_dst[1] = 8080;
 	g_assert(check_parameters(params) == OK);
-	
+
 	params->port_dst[0] = 8081;
 	g_assert(check_parameters(params) == INVALID_PORT_RANGE);
-	
+
 	params->port_dst[0] = 80;
 	g_assert(check_parameters(params) == OK);
-		
-	for(i = 0; i < 4 ; i++)
-	{
+
+	for(i = 0; i < 4 ; i++) {
 		params->operation = i;
 		if(i < 2)
 			g_assert(check_parameters(params) == OK);
 		else
 			g_assert(check_parameters(params) == INVALID_REQUEST);
 	}
-	
+
 	reset_params_ports(params);
-	
+
 	params->operation = 0;
-	
+
 /* all ports */
 	params->port_dst[0] = params->port_dst[1] = 8080;
 	params->port_src[0] = params->port_src[1] = 8082;
 	g_assert(check_parameters(params) == OK);
-	
+
 	params->port_dst[0] = 8081;
 	g_assert(check_parameters(params) == INVALID_PORT_RANGE);
-	
+
 	params->port_dst[0] = 80; // ok
 	params->port_src[0] = 8083; // not ok
 	g_assert(check_parameters(params) == INVALID_PORT_RANGE);
-	
+
 	params->port_src[0] = 8080;
 	g_assert(check_parameters(params) == OK);
-	
-	for(i = 0; i < 4 ; i++)
-	{
+
+	for(i = 0; i < 4 ; i++) {
 		params->operation = i;
 		if(i < 2)
 			g_assert(check_parameters(params) == OK);
@@ -682,85 +674,85 @@ static void ip_port_and_range_full_positive(rule_params *params)
 static void ip_port_and_range_full_negative(rule_params *params)
 {
 	g_assert(params);
-	
+
 	reset_params_ports(params);
-	
+
 	params->operation = 0;
 
 /* src ports */
 	params->port_src[0] = 8080;
 	g_assert(check_parameters(params) == INVALID_PORT);
-	
+
 	params->port_src[0] = 0;
 	params->port_src[1] = 8080;
 	g_assert(check_parameters(params) == INVALID_PORT);
-	
+
 	params->port_src[0] = 8081;
 	params->port_src[1] = 8080;
 	g_assert(check_parameters(params) == INVALID_PORT_RANGE);
-	
+
 	params->port_src[0] = 8080;
 	params->port_src[1] = 8080;
 	g_assert(check_parameters(params) == OK);
-	
+
 	reset_params_ports(params);
 
 /* dst ports */
 	params->port_dst[0] = 8080;
 	g_assert(check_parameters(params) == INVALID_PORT);
-	
+
 	params->port_dst[0] = 0;
 	params->port_dst[1] = 8080;
 	g_assert(check_parameters(params) == INVALID_PORT);
-	
+
 	params->port_dst[0] = 8081;
 	params->port_dst[1] = 8080;
 	g_assert(check_parameters(params) == INVALID_PORT_RANGE);
-	
+
 	params->port_dst[0] = 8080;
 	params->port_dst[1] = 8080;
 	g_assert(check_parameters(params) == OK);
-	
+
 	reset_params_ports(params);
-	
+
 /* all ports */
 
 	// src 0 + dst 0
 	params->port_dst[0] = 8080;
 	params->port_src[0] = 8082;
 	g_assert(check_parameters(params) == INVALID_PORT);
-	
+
 	// src 0 + dst 1
 	params->port_dst[0] = 0;
 	params->port_dst[1] = 8080;
 	g_assert(check_parameters(params) == INVALID_PORT);
-	
+
 	// src 1 + dst 0
 	params->port_src[0] = 0;
 	params->port_src[1] = 8083;
 	params->port_dst[0] = 0;
 	g_assert(check_parameters(params) == INVALID_PORT);
-	
+
 	// src 1 + dst 1
 	reset_params_ports(params);
 	params->port_src[1] = 8083;
 	params->port_dst[1] = 8080;
 	g_assert(check_parameters(params) == INVALID_PORT);
-	
+
 	reset_params_ports(params);
-	
+
 // Ranges
 	params->port_dst[0] = 8080;
 	params->port_src[0] = 8082;
 	g_assert(check_parameters(params) == INVALID_PORT);
-	
+
 	params->port_dst[1] = 90;
 	params->port_src[1] = 90;
 	g_assert(check_parameters(params) == INVALID_PORT_RANGE);
-	
+
 	params->port_dst[1] = 8081;
 	g_assert(check_parameters(params) == INVALID_PORT_RANGE);
-	
+
 	params->port_src[1] = 8083;
 	g_assert(check_parameters(params) == OK);
 
@@ -770,63 +762,63 @@ static void test_iptables_plugin_parameters_ip_and_port_range_full()
 {
 	/* Port and ip  : ARGS_IP_PORT */
 	rule_params *params = rule_params_new(ARGS_IP_PORT_RANGE);
-	
+
 	full_parameter_prepare(params);
-	
+
 	g_assert(check_parameters(params) == INVALID_IP);
-	
+
 	params->protocol = g_strdup("tcp");
-	
+
 /* src ip */
 	params->ip_src = g_strdup("192.168.10.1");
 	g_assert(check_parameters(params) == INVALID_PORT);
-	
+
 	ip_port_and_range_full_positive(params);
-	
+
 	reset_params_ips(params);
 	reset_params_ports(params);
-	
+
 /* dst ip */	
 
 	params->ip_dst = g_strdup("192.168.10.1");
 	g_assert(check_parameters(params) == INVALID_PORT);
-	
+
 	ip_port_and_range_full_positive(params);
-	
+
 	reset_params_ports(params);
-	
+
 /* both */
 	params->ip_src = g_strdup("192.168.10.1");
 	g_assert(check_parameters(params) == INVALID_PORT);
-	
+
 	ip_port_and_range_full_positive(params);
-	
+
 	reset_params_ips(params);
 	reset_params_ports(params);
 
 /* Negative src */
 	params->ip_src = g_strdup("192.168.10.1");
 	g_assert(check_parameters(params) == INVALID_PORT);
-	
+
 	ip_port_and_range_full_negative(params);
-	
+
 	reset_params_ips(params);
 	reset_params_ports(params);
 
 /* Negative dst */
 	params->ip_dst = g_strdup("192.168.10.1");
 	g_assert(check_parameters(params) == INVALID_PORT);
-	
+
 	ip_port_and_range_full_negative(params);
-	
+
 	reset_params_ports(params);
-	
+
 /* Negative both*/
 	params->ip_src = g_strdup("192.168.10.2");
 	g_assert(check_parameters(params) == INVALID_PORT);
-	
+
 	ip_port_and_range_full_negative(params);
-	
+
 	rule_params_free(params);
 }
 
@@ -834,17 +826,17 @@ static void test_iptables_plugin_parameters_port_range_full()
 {
 	/* Port and ip  : ARGS_PORT_RANGE */
 	rule_params *params = rule_params_new(ARGS_PORT_RANGE);
-	
+
 	full_parameter_prepare(params);
-	
+
 	g_assert(check_parameters(params) == INVALID_PORT);
-	
+
 	params->protocol = g_strdup("tcp");
-	
+
 	ip_port_and_range_full_positive(params);
-	
+
 	reset_params_ports(params);
-	
+
 	ip_port_and_range_full_negative(params);
 
 	rule_params_free(params);
@@ -855,81 +847,79 @@ static void test_iptables_plugin_parameters_service_full()
 	/* service  : ARGS_SERVICE */
 	rule_params *params = rule_params_new(ARGS_SERVICE);
 	guint16 i = 0;
-	
+
 	g_assert(params);
-	
+
 	full_parameter_prepare(params);
 
 	g_assert(check_parameters(params) == INVALID_SERVICE);
-	
+
 	params->service_src = g_strdup("http");
 	g_assert(check_parameters(params) == INVALID_SERVICE);
-	
+
 	params->protocol = g_strdup("tcp");
 	g_assert(check_parameters(params) == INVALID_REQUEST);
-	
-	for(i = 2; i < 4 ; i++)
-	{
+
+	for(i = 2; i < 4 ; i++) {
 		params->operation = i;
 		g_assert(check_parameters(params) == INVALID_REQUEST);
 	}
 
-	for(i = 0; i < 2 ; i++)
-	{
+	for(i = 0; i < 2 ; i++) {
 		params->operation = i;
 		g_assert(check_parameters(params) == OK);
 	}
-		
+
 	rule_params_free(params);
 }
 
 static void test_iptables_plugin_parameters_check_icmp_full()
 {
 	rule_params *params = rule_params_new(ARGS_ICMP);
-	
+
 	g_assert(params);
-	
+
 	full_parameter_prepare(params);
 	g_assert(check_parameters(params) == INVALID_ICMP);
-	
+
 	params->icmp[0] = params->icmp[1] = 0;
 	g_assert(check_parameters(params) == INVALID_REQUEST);
-	
+
 	params->operation = ADD;
 	g_assert(check_parameters(params) == OK);
-	
+
 	params->icmp[0] = 8;
 	params->icmp[1] = 15;
 	g_assert(check_parameters(params) == OK);
-	
+
 	params->icmp[0] = params->icmp[1] = G_MAXUINT16;
 	g_assert(check_parameters(params) == INVALID_ICMP);
-	
+
 	params->icmp[0] = 160;
 	g_assert(check_parameters(params) == INVALID_ICMP);
-	
+
 	params->icmp[0] = 0xffff;
 	params->icmp[1] = 1;
 	g_assert(check_parameters(params) == INVALID_ICMP);
-	
+
 	params->args = ARGS_IP_ICMP;
 	g_assert(check_parameters(params) == INVALID_IP);
-	
+
 	params->ip_src = g_strdup("192.168.10.1");
 	g_assert(check_parameters(params));
-	
+
 	params->ip_dst = g_strdup("192.168.10.1");
 	g_assert(check_parameters(params) == INVALID_ICMP);
-	
+
 	params->icmp[0] = 8;
 	params->icmp[1] = 15;
 	g_assert(check_parameters(params) == OK);
-	
+
 	params->icmp[0] = params->icmp[1] = G_MAXUINT16;
 	g_free(params->ip_src);
 	params->ip_src = NULL;
 	g_assert(check_parameters(params) == INVALID_ICMP);
-	
+
 	params->icmp[0] = params->icmp[1] = 0;
 	g_assert(check_parameters(params) == OK);
 
@@ -941,32 +931,30 @@ static void test_iptables_plugin_parameters_chain()
 	/* service  : ARGS_SERVICE */
 	rule_params *params = rule_params_new(ARGS_CHAIN);
 	guint16 i = 0;
-	
+
 	g_assert(params);
 
 	g_assert(check_parameters(params) == INVALID_CHAIN_NAME);
-	
+
 	params->chain = g_strdup("chain1");
 	g_assert(check_parameters(params) == INVALID_REQUEST);
-	
+
 	params->table = g_strdup("table");
 	g_assert(check_parameters(params) == INVALID_REQUEST);
-	
-	for(i = 3; i < 5 ; i++)
-	{
+
+	for(i = 3; i < 5 ; i++) {
 		params->operation = i;
 		g_assert(check_parameters(params) == INVALID_REQUEST);
 	}
 
-	for(i = 0; i < 2 ; i++)
-	{
+	for(i = 0; i < 2 ; i++) {
 		params->operation = i;
 		g_assert(check_parameters(params) == OK);
 	}
-	
+
 	params->operation = 0;
-	
-	
+
+
 	rule_params_free(params);
 }
 
@@ -974,38 +962,34 @@ static void test_iptables_plugin_parameters_check_operation()
 {
 	rule_params *params = rule_params_new(ARGS_CHAIN);
 	guint16 i = 0;
-	
+
 	g_assert(params);
 	g_assert(!check_operation(NULL));
-	
+
 	// ADD, REMOVE and FLUSH ok for ARGS_CHAIN
-	for(i = 0; i < 3 ; i++)
-	{
+	for(i = 0; i < 3 ; i++) {
 		params->operation = i;
 		g_assert(check_operation(params));
 	}
-	
-	for(i = 3; i < 5 ; i++)
-	{
+
+	for(i = 3; i < 5 ; i++) {
 		params->operation = i;
 		g_assert(!check_operation(params));
 	}
-	
+
 	params->args = ARGS_IP;
-	
+
 	// ADD, REMOVE and FLUSH ok for rest that require operation
-	for(i = 0; i < 2 ; i++)
-	{
+	for(i = 0; i < 2 ; i++) {
 		params->operation = i;
 		g_assert(check_operation(params));
 	}
-	
-	for(i = 2; i < 5 ; i++)
-	{
+
+	for(i = 2; i < 5 ; i++) {
 		params->operation = i;
 		g_assert(!check_operation(params));
 	}
-	
+
 	rule_params_free(params);
 }
 
@@ -1013,43 +997,42 @@ static void test_iptables_plugin_parameters_check_ips()
 {
 	gint i = 0;
 	rule_params *params = rule_params_new(ARGS_IP);
-	
+
 	g_assert(params);
-	
-	for(i = ARGS_IP ; i <= ARGS_IP_SERVICE ; i++)
-	{
+
+	for(i = ARGS_IP ; i <= ARGS_IP_SERVICE ; i++) {
 		params->args = i;
-		
+
 		// src NULL, dst NULL = false
 		g_assert(!check_ips(params));
-		
+
 		// src NULL, dst data = true
 		params->ip_dst = g_strdup("1.2.3.4");
 		g_assert(check_ips(params));
-		
+
 		// src data, dst data = true
 		params->ip_src = g_strdup("1.2.3.4");
 		g_assert(check_ips(params));
-		
+
 		g_free(params->ip_dst);
 		params->ip_dst = NULL;
-		
+
 		// src data, dst NULL, true
 		g_assert(check_ips(params));
-		
+
 		g_free(params->ip_src);
 		params->ip_src = NULL;
 	}
-	
+
 	rule_params_free(params);
 }
 
 static void test_iptables_plugin_parameters_check_ports()
 {
 	rule_params *params = rule_params_new(ARGS_IP_PORT);
-	
+
 	gint i = 0;
-	
+
 	gint basic_full[] = {
 		ARGS_IP_PORT,
 		ARGS_IP_SERVICE,
@@ -1057,243 +1040,229 @@ static void test_iptables_plugin_parameters_check_ports()
 		ARGS_SERVICE,
 		0
 	};
-	
+
 	gint src_and_dest_range[] = {
 		ARGS_IP_PORT_RANGE,
 		ARGS_PORT_RANGE,
 		0
 	};
-	
+
 	g_assert(params);
-	
+
 	g_assert(!check_ports(params));
-	
+
 /*--------------BASIC FULL--------------*/
 	// Should fail
-	for(i = 0; basic_full[i] ; i++)
-	{
+	for(i = 0; basic_full[i] ; i++) {
 		params->args = basic_full[i];
 		g_assert(!check_ports(params));
 	}
-	
+
 	// Only one set - ok  as either should be set
 	params->port_dst[0] = 80;
-	
-	for(i = 0; basic_full[i] ; i++)
-	{
+
+	for(i = 0; basic_full[i] ; i++) {
 		params->args = basic_full[i];
 		g_assert(check_ports(params));
 	}
-	
+
 	// Both set, ok
 	params->port_src[0] = 8080;
-	
-	for(i = 0; basic_full[i] ; i++)
-	{
+
+	for(i = 0; basic_full[i] ; i++) {
 		params->args = basic_full[i];
 		g_assert(check_ports(params));
 	}
-	
+
 	// Only one set, ok
 	params->port_dst[0] = 0;
-	
-	for(i = 0; basic_full[i] ; i++)
-	{
+
+	for(i = 0; basic_full[i] ; i++) {
 		params->args = basic_full[i];
 		g_assert(check_ports(params));
 	}
-	
+
 	// Reset	
 	params->port_dst[0] = params->port_dst[1] = params->port_src[0] = params->port_src[1] = 0;
 
 /*--------------FULL RANGE------------------*/
-	for(i = 0; src_and_dest_range[i] ; i++)
-	{
+	for(i = 0; src_and_dest_range[i] ; i++) {
 		params->args = src_and_dest_range[i];
 		g_assert(!check_ports(params));
 	}
-	
+
 	// Either dst or src set should be ok (or both)
 	params->port_dst[0] = 80;
-	
-	for(i = 0; src_and_dest_range[i] ; i++)
-	{
+
+	for(i = 0; src_and_dest_range[i] ; i++) {
 		params->args = src_and_dest_range[i];
 		g_assert(!check_ports(params));
 	}
-	
+
 	// Fail as dst and src [0] are only set
 	params->port_src[0] = 8080;
-	
-	for(i = 0; src_and_dest_range[i] ; i++)
-	{
+
+	for(i = 0; src_and_dest_range[i] ; i++) {
 		params->args = src_and_dest_range[i];
 		g_assert(!check_ports(params));
 	}
-	
+
 	// Ok, at least dst set
 	params->port_dst[1] = 443;
-	
-	for(i = 0; src_and_dest_range[i] ; i++)
-	{
+
+	for(i = 0; src_and_dest_range[i] ; i++) {
 		params->args = src_and_dest_range[i];
 		g_assert(check_ports(params));
 	}
-	
+
 	// Ok all set
 	params->port_src[1] = 8088;
-	
-	for(i = 0; src_and_dest_range[i] ; i++)
-	{
+
+	for(i = 0; src_and_dest_range[i] ; i++) {
 		params->args = src_and_dest_range[i];
 		g_assert(check_ports(params));
 	}
-	
+
 	// Succeeds, as src has both
 	params->port_dst[0] = 0;
-	
-	for(i = 0; src_and_dest_range[i] ; i++)
-	{
+
+	for(i = 0; src_and_dest_range[i] ; i++) {
 		params->args = src_and_dest_range[i];
 		g_assert(check_ports(params));
 	}
-	
+
 	// fails
 	params->port_src[0] = 0;
-	
-	for(i = 0; src_and_dest_range[i] ; i++)
-	{
+
+	for(i = 0; src_and_dest_range[i] ; i++) {
 		params->args = src_and_dest_range[i];
 		g_assert(!check_ports(params));
 	}
-	
+
 	// fails
 	params->port_dst[1] = 0;
-	
-	for(i = 0; src_and_dest_range[i] ; i++)
-	{
+
+	for(i = 0; src_and_dest_range[i] ; i++) {
 		params->args = src_and_dest_range[i];
 		g_assert(!check_ports(params));
 	}
-	
+
 	rule_params_free(params);
 }
 
 static void test_iptables_plugin_parameters_check_service()
 {
 	rule_params *params = rule_params_new(ARGS_SERVICE);
-	
+
 	g_assert(params);
-	
+
 	gint full[] = { ARGS_SERVICE, ARGS_IP_SERVICE, 0 };
 	gint i = 0;
 
-	for(i = 0; full[i]; i++)
-	{
+	for(i = 0; full[i]; i++) {
 		params->args = full[i];
-		
+
 		g_assert(!check_service(params));
-	
+
 		params->service_dst = g_strdup("http");
 		g_assert(check_service(params));
-	
+
 		params->service_src = g_strdup("ssh");
 		g_assert(check_service(params));
-	
+
 		g_free(params->service_dst);
 		params->service_dst = NULL;
 		g_assert(check_service(params));
-	
+
 		g_free(params->service_src);
 		params->service_src = NULL;
 		g_assert(!check_service(params));
-	
+
 		g_free(params->service_dst);
 		g_free(params->service_src);
 		params->service_dst = params->service_src = NULL;
 	}
-	
+
 	rule_params_free(params);
 }
 
 static void test_iptables_plugin_parameters_check_chain_restricted()
 {
 	rule_params *params = rule_params_new(ARGS_POLICY);
-	
+
 	g_assert(params);
-	
+
 	gint i = 0;
-	const gchar const * DEFAULT_CHAINS[] = {
+	const gchar *default_chains[] = {
 		"INPUT",
 		"OUTPUT",
 		"FORWARD",
 		NULL
 	};
-	
+
 	g_assert(!check_chain_restricted(NULL));
 	g_assert(!check_chain_restricted(params));
-	
-	for(i = 0; DEFAULT_CHAINS[i]; i++)
-	{
-		params->chain = g_strdup(DEFAULT_CHAINS[i]);
-		
+
+	for(i = 0; default_chains[i]; i++) {
+		params->chain = g_strdup(default_chains[i]);
+
 		g_assert(check_chain_restricted(params));
-		
+
 		g_free(params->chain);
 	}
-	
+
 	params->chain = g_strdup("CUSTOM1");
 	g_assert(!check_chain_restricted(params));
-	
+
 	rule_params_free(params);
 }
 
 static void test_iptables_plugin_parameters_check_port_range()
 {
 	rule_params *params = rule_params_new(ARGS_PORT_RANGE);
-	
+
 	g_assert(params);
-	
+
 	params->port_src[0] = 22;
 	g_assert(!check_port_range(params));
-	
+
 	params->port_src[1] = 21;
 	g_assert(!check_port_range(params));
 
 	params->port_src[1] = 22;
 	g_assert(check_port_range(params));	
-	
+
 	params->port_src[1] = 23;
 	g_assert(check_port_range(params));
-	
+
 	rule_params_free(params);
 }
 
 static void test_iptables_plugin_parameters_check_icmp()
 {
 	rule_params *params = rule_params_new(ARGS_ICMP);
-	
+
 	g_assert(params);
-	
+
 	g_assert(!check_icmp(params));
-	
+
 	params->icmp[0] = params->icmp[1] = 0;
-	
+
 	g_assert(check_icmp(params));
-	
+
 	params->icmp[0] = 8;
 	params->icmp[1] = 15;
-	
+
 	g_assert(check_icmp(params));
-	
+
 	params->icmp[0] = 161;
-	
+
 	g_assert(check_icmp(params));
 
 	params->icmp[1] = G_MAXUINT16;
 
 	g_assert(!check_icmp(params));
-	
+
 	params->icmp[0] = G_MAXUINT16;
 	params->icmp[1] = 1;
 	g_assert(!check_icmp(params));
@@ -1304,30 +1273,30 @@ static void test_iptables_plugin_parameters_check_icmp()
 static void test_iptables_plugin_parameters_dbus_client()
 {
 	dbus_client* client = dbus_client_new();
-	
+
 	g_assert(client);
 	g_assert(!client->peer);
 	g_assert(!client->watch_id);
-	
+
 	dbus_client_free(client);
-	
+
 	client = dbus_client_new();
-	
+
 	dbus_client_free1(client);	
 }
 
 static void test_iptables_plugin_parameters_api_data()
 {
 	gint i = 0, max = 5;
-	const gchar const * NAMES[] = {"name1", "name2", "name3", "name4", "name5", 
+	const gchar *names[] = {"name1", "name2", "name3", "name4", "name5", 
 		NULL};
 	api_data *data = api_data_new();
-	
+
 	g_assert(data);
 	g_assert(data->clients);
 	g_assert(data->policy);
 	g_assert(!data->custom_chains);
-	
+
 	dbus_client* tmp = dbus_client_new();
 	DAPeer* peer_tmp = g_new0(DAPeer,1);
 
@@ -1339,23 +1308,22 @@ static void test_iptables_plugin_parameters_api_data()
 	g_assert(!api_data_add_peer(data, tmp));
 
 	dbus_client_free(tmp);
-	
+
 	g_assert(!api_data_get_peer(NULL,NULL));
 	g_assert(!api_data_get_peer(data,NULL));
 	g_assert(!api_data_get_peer(data,""));
-	g_assert(!api_data_get_peer(data,NAMES[0]));
-	
+	g_assert(!api_data_get_peer(data, names[0]));
+
 	g_assert(!api_data_remove_peer(NULL,NULL));
 	g_assert(!api_data_remove_peer(data,NULL));
 	g_assert(!api_data_remove_peer(data,""));
-	g_assert(!api_data_remove_peer(data,NAMES[0]));
-	
-	for(i = 0; i < max; i++)
-	{
+	g_assert(!api_data_remove_peer(data, names[0]));
+
+	for(i = 0; i < max; i++) {
 		dbus_client* client = dbus_client_new();
-		
+
 		DAPeer* peer = g_new0(DAPeer,1);
-		peer->name = g_strdup(NAMES[i]);
+		peer->name = g_strdup(names[i]);
 
 		DACred cred = {
 			0, 0,
@@ -1363,20 +1331,20 @@ static void test_iptables_plugin_parameters_api_data()
 			G_GUINT64_CONSTANT(0xfffffff008003420),
 			DBUSACCESS_CRED_CAPS | DBUSACCESS_CRED_GROUPS
 		};
-	
+
 		peer->cred = cred;
 		peer->bus = DA_BUS_SYSTEM;
-		
+
 		client->peer = peer;
-	
+
 		g_assert(api_data_add_peer(data,client));
 		g_assert(g_hash_table_size(data->clients) == i+1);
-		g_assert(api_data_get_peer(data,NAMES[i]));
+		g_assert(api_data_get_peer(data, names[i]));
 	}
-	
-	g_assert(api_data_remove_peer(data,NAMES[0]));
+
+	g_assert(api_data_remove_peer(data, names[0]));
 	g_assert(g_hash_table_size(data->clients) == max-1);
-	
+
 	api_data_free(data);
 }
 
@@ -1384,37 +1352,37 @@ static void test_iptables_plugin_parameters_custom_chains()
 {
 	custom_chain_item *item = NULL;
 	gint i = 0;
-	const gchar const * chains[] = {"chain1", "chain2", "chain3", NULL};
-	
+	const gchar *chains[] = {"chain1", "chain2", "chain3", NULL};
+
 	g_assert(!custom_chain_item_new(NULL));
 	item = custom_chain_item_new("test");
 	g_assert(item);
 	g_assert(!g_ascii_strcasecmp(item->table,"test"));
 	g_assert(!item->chains);
-	
+
 	g_assert(!custom_chain_item_add_to_chains(NULL, NULL));
 	g_assert(!custom_chain_item_add_to_chains(item, NULL));
 	g_assert(!custom_chain_item_add_to_chains(NULL, "chain"));
-	
+
 	for(i = 0; chains[i] ; i++)
 		g_assert(custom_chain_item_add_to_chains(item,chains[i]));
-	
+
 	g_assert(g_list_length(item->chains) == i);
-	
+
 	g_assert(!custom_chain_item_remove_from_chains(item,NULL));
 	g_assert(!custom_chain_item_remove_from_chains(item,""));
 	g_assert(!custom_chain_item_remove_from_chains(item,"chain"));
-	
+
 	g_assert(custom_chain_item_remove_from_chains(item,chains[2]));
 	g_assert(g_list_length(item->chains) == i - 1);
-	
+
 	g_assert(custom_chain_item_remove_from_chains(item,chains[0]));
 	g_assert(!custom_chain_item_remove_from_chains(item,chains[0]));
-	
+
 	g_assert(custom_chain_item_remove_from_chains(item,chains[1]));
-	
+
 	g_assert(!g_list_length(item->chains));
-	
+
 	custom_chain_item_free(item);
 
 }
@@ -1422,59 +1390,59 @@ static void test_iptables_plugin_parameters_custom_chains()
 static void test_iptables_plugin_parameters_api_data_chains()
 {
 	gint i = 0;
-	const gchar const * NAMES[] = {"chain1", "chain2", "chain3", "chain4", NULL};
+	const gchar *names[] = {"chain1", "chain2", "chain3", "chain4", NULL};
 	GList *chains = NULL;
 	custom_chain_item *item = NULL;
-	
+
 	api_data *data = api_data_new();
-	
+
 	g_assert(!data->custom_chains);
-	
+
 	g_assert(!api_data_get_custom_chain_table(NULL, NULL));
 	g_assert(!api_data_get_custom_chain_table(data, NULL));
 	g_assert(!api_data_get_custom_chain_table(NULL, "filter"));
 	g_assert(!api_data_get_custom_chain_table(data, "filter"));
-	
+
 	g_assert(!api_data_remove_custom_chains(NULL, NULL));
 	g_assert(!api_data_remove_custom_chains(data, NULL));
 	g_assert(!api_data_remove_custom_chains(NULL, "filter"));
-	
+
 	// List null, nothing done = true
 	g_assert(api_data_remove_custom_chains(data, "filter"));
-	
+
 	g_assert(!api_data_add_custom_chain(NULL, NULL, NULL));
 	g_assert(!api_data_add_custom_chain(data, NULL, NULL));
 	g_assert(!api_data_add_custom_chain(data, "filter", NULL));
 	g_assert(!api_data_add_custom_chain(NULL, "filter", "chain"));
 	g_assert(!api_data_add_custom_chain(NULL, NULL, "chain"));
-	
-	for(i = 0 ; NAMES[i] ; i++)
-		g_assert(api_data_add_custom_chain(data, "filter", NAMES[i]));
-	
+
+	for(i = 0 ; names[i] ; i++)
+		g_assert(api_data_add_custom_chain(data, "filter", names[i]));
+
 	chains = api_data_get_custom_chain_table(data, "filter");
 	g_assert(chains);
 	item = (custom_chain_item*)chains->data;
 	g_assert(g_list_length(item->chains) == i);
-	
+
 	// Try to remove nonexisting
 	g_assert(!api_data_delete_custom_chain(data,"filter","test2"));
-	
+
 	chains = api_data_get_custom_chain_table(data, "filter");
 	g_assert(chains);
 	item = (custom_chain_item*)chains->data;
 	g_assert(g_list_length(item->chains) == i);
-	
+
 	// Remove existing
-	g_assert(api_data_delete_custom_chain(data,"filter", NAMES[0]));
-	
+	g_assert(api_data_delete_custom_chain(data,"filter", names[0]));
+
 	chains = api_data_get_custom_chain_table(data, "filter");
 	g_assert(chains);
 	item = (custom_chain_item*)chains->data;
 	g_assert(g_list_length(item->chains) == i-1);
-	
+
 	g_assert(!api_data_remove_custom_chains(data,"filter1"));
 	g_assert(api_data_remove_custom_chains(data,"filter"));
-	
+
 	api_data_free(data);
 }
 
@@ -1483,27 +1451,27 @@ static void test_iptables_plugin_parameters_disconnect_data()
 	api_data* a_data = api_data_new();
 	dbus_client* client = dbus_client_new();
 	client_disconnect_data *cd_data = NULL;
-	
+
 	g_assert(!client_disconnect_data_new(NULL,NULL));
 	g_assert(!client_disconnect_data_new(a_data, NULL));
 	g_assert(!client_disconnect_data_new(a_data, client));
-	
+
 	DAPeer* peer = g_new0(DAPeer,1);
 	gchar *peer_name = g_strdup("peer");
 	peer->name = peer_name;
-		
+
 	client->peer = peer;
-	
+
 	cd_data = client_disconnect_data_new(a_data, client);
 	g_assert(cd_data);
 	g_assert(cd_data->main_data);
 	g_assert(cd_data->client_name);
 	client_disconnect_data_free(cd_data);
-	
+
 	g_free(peer_name);
 	g_free(peer);
 	client->peer = NULL;
-	
+
 	dbus_client_free(client);
 	api_data_free(a_data);
 }
@@ -1512,7 +1480,7 @@ static void test_iptables_plugin_parameters_disconnect_data()
 static void test_iptables_plugin_negated_ip_address()
 {
 	g_assert(negated_ip_address("!192.168.10.1"));
-	
+
 	g_assert(!negated_ip_address("192.168.10.1"));
 	g_assert(!negated_ip_address(NULL));
 
@@ -1524,7 +1492,7 @@ static void test_iptables_plugin_validate_address()
 	g_assert(validate_address(IPV4,"10.0.0.1"));
 	g_assert(validate_address(IPV4,"8.8.8.8"));
 	g_assert(validate_address(IPV4,"0.0.0.0"));
-	
+
 	// IPv6
 	g_assert(validate_address(IPV6,"fe80::200:5aee:feaa:20a2"));
 	g_assert(validate_address(IPV6,"2001:db8:3333:4444:5555:6666:7777:8888"));
@@ -1535,7 +1503,7 @@ static void test_iptables_plugin_validate_address()
 	g_assert(validate_address(IPV6,"::1234:5678"));
 	g_assert(validate_address(IPV6,"2001:db8::1234:5678"));
 	g_assert(validate_address(IPV6,"2001:0db8:0001:0000:0000:0ab9:C0A8:0102"));
-	
+
 	g_assert(validate_address(IPV6,"::FFFF:8.8.8.8"));
 	g_assert(validate_address(IPV6,"2001:db8:3333:4444:5555:6666:1.2.3.4"));
 	g_assert(validate_address(IPV6,"::11.22.33.44"));
@@ -1543,23 +1511,23 @@ static void test_iptables_plugin_validate_address()
 	g_assert(validate_address(IPV6,"::1234:5678:91.123.4.56"));
 	g_assert(validate_address(IPV6,"::1234:5678:1.2.3.4"));
 	g_assert(validate_address(IPV6,"2001:db8::1234:5678:5.6.7.8"));
-	
-	
+
+
 	g_assert(!validate_address(IPV4,""));
 	g_assert(!validate_address(IPV4,NULL));
-	
+
 	g_assert(!validate_ip_address(IPV4,"256.256.256.256"));
 
 	g_assert(!validate_address(IPV4,"192.168.1"));
 	g_assert(!validate_address(IPV4,"192.168"));
 	g_assert(!validate_address(IPV4,"192"));
-	
+
 	g_assert(!validate_address(IPV4,"192.168.1."));
 	g_assert(!validate_address(IPV4,"192.168.."));
 	g_assert(!validate_address(IPV4,"192..."));
-	
+
 	g_assert(!validate_address(IPV4,"jolla.com"));
-	
+
 	g_assert(!validate_address(IPV4,"015.014.013.012"));
 }
 
@@ -1568,31 +1536,30 @@ static void test_iptables_plugin_validate_mask()
 	struct in_addr addr;
 	memset(&addr,0,sizeof(struct in_addr));
 	gint mask = 0;
-	
+
 	g_assert(inet_aton("255.255.255.255", &addr));
-	
+
 	// Check all valid masks
-	for(mask = 32 ; mask >= 0 ; mask--)
-	{
+	for(mask = 32 ; mask >= 0 ; mask--) {
 		g_assert(validate_ip_mask(IPV4,inet_ntoa(addr)));
-		
+
 		gchar *mask_str = g_strdup_printf("%d",mask);
 		g_assert(validate_ip_mask(IPV4, mask_str));
 		g_free(mask_str);
-		
+
 		// Reduce one up bit from mask, 255.255.255.254, 255.255.255.252 etc.
 		in_addr_t addr_int = ntohl(addr.s_addr);
 		addr_int <<= 1;
 		addr.s_addr = htonl(addr_int);
 	}
-	
+
 	g_assert(validate_ip_mask(IPV4, "0.0.0.0"));
-	
+
 	g_assert(!validate_ip_mask(IPV4, "255.255.123.1"));
 	g_assert(!validate_ip_mask(IPV4, "192.168.10.0"));
 	g_assert(!validate_ip_mask(IPV4, "10.10.10.10"));
 	g_assert(!validate_ip_mask(IPV4, "8.8.8.8"));
-	
+
 	g_assert(!validate_ip_mask(IPV4,""));
 	g_assert(!validate_ip_mask(IPV4,NULL));
 }
@@ -1602,15 +1569,15 @@ static void test_iptables_plugin_validate_ip_address()
 	g_assert(validate_ip_address(IPV4,"8.8.8.8"));
 	g_assert(validate_ip_address(IPV4,"192.168.10.1"));
 	g_assert(validate_ip_address(IPV4,"192.168.1.0"));
-	
+
 	g_assert(validate_ip_address(IPV4,"!10.10.10.10"));
-	
+
 	g_assert(validate_ip_address(IPV4,"192.168.1.0/255.255.255.0"));
 	g_assert(validate_ip_address(IPV4,"192.168.1.0/24"));
-	
+
 	g_assert(validate_ip_address(IPV4,"!192.168.1.0/255.255.255.0"));
 	g_assert(validate_ip_address(IPV4,"!192.168.1.0/24"));
-	
+
 	g_assert(!validate_ip_address(IPV4,""));
 	g_assert(!validate_ip_address(IPV4,NULL));
 }
@@ -1618,7 +1585,7 @@ static void test_iptables_plugin_validate_ip_address()
 static void test_iptables_plugin_validate_service_name()
 {
 	g_assert(validate_service_name("ssh"));
-	
+
 	g_assert(!validate_service_name("tcp"));
 	g_assert(!validate_service_name(""));
 	g_assert(!validate_service_name(NULL));
@@ -1631,7 +1598,7 @@ static void test_iptables_plugin_validate_protocol()
 	g_assert(validate_protocol("sctp"));
 	g_assert(validate_protocol("icmp"));
 	g_assert(validate_protocol("TCP"));
-	
+
 	g_assert(!validate_protocol("ssh"));
 	g_assert(!validate_protocol(""));
 	g_assert(!validate_protocol(NULL));
@@ -1645,22 +1612,22 @@ static void test_iptables_plugin_validate_port()
 	g_assert(validate_port(0xFFFF));
 	g_assert(validate_port(0xDEAD));
 	g_assert(validate_port(0xBEEF));
-	
+
 	g_assert(!validate_port(0));
 }
 
 static void test_iptables_plugin_validate_operation()
 {
 	g_assert(validate_operation(0) == ADD);
-	
+
 	g_assert(validate_operation(1) == REMOVE);
-	
+
 	g_assert(validate_operation(2) == FLUSH);
-	
+
 	g_assert(validate_operation(3) == UNDEFINED);
-	
+
 	g_assert(validate_operation(42) == UNDEFINED);
-	
+
 	g_assert(validate_operation(-1) == UNDEFINED);
 }
 
@@ -1668,64 +1635,63 @@ static void test_iptables_plugin_validate_chain()
 {
 	gint i = 0;
 	const gchar *table = "filter";
-	const gchar const * CHAINS[] = {"INPUT", "OUTPUT", "FORWARD", "CUSTOM1", NULL};
+	const gchar *chains[] = {"INPUT", "OUTPUT", "FORWARD", "CUSTOM1", NULL};
 	gchar *chain = NULL;
-	
+
 	g_assert(!validate_chain(NULL,NULL));
 	g_assert(!validate_chain(NULL,""));
 	g_assert(!validate_chain("",NULL));
 	g_assert(!validate_chain("",""));
-	
+
 	g_assert(!validate_chain(table,NULL));
 	g_assert(!validate_chain(table,""));
 
-	for(i = 0; CHAINS[i]; i++)
-	{
-		chain = validate_chain(table, CHAINS[i]);
+	for(i = 0; chains[i]; i++) {
+		chain = validate_chain(table, chains[i]);
 		g_assert(chain);
-		
+
 		if(i == 3)
 			g_assert(!g_ascii_strcasecmp(chain, "sfos_CUSTOM1"));
 		else
-			g_assert(!g_ascii_strcasecmp(chain, CHAINS[i]));
-			
+			g_assert(!g_ascii_strcasecmp(chain, chains[i]));
+
 		g_free(chain);
 	}
-	
+
 	g_assert(!validate_chain(table,"CUSTOM2"));
 }
 
 static void test_iptables_plugin_validate_target()
 {
 	gint i = 0;
-	const gchar const * PASS[] = {"ACCEPT", "DROP", "QUEUE", "RETURN", "REJECT", "CUSTOM1", NULL};
-	const gchar const * FAIL[] = {"INPUT", "OUTPUT", "FORWARD", "CUSTOM2", NULL};
+	const gchar *pass[] = {"ACCEPT", "DROP", "QUEUE", "RETURN", "REJECT",
+				"CUSTOM1", NULL};
+	const gchar *fail[] = {"INPUT", "OUTPUT", "FORWARD", "CUSTOM2", NULL};
 	const gchar *table = "filter";
 	gchar *target = NULL;
-	
+
 	g_assert(!validate_target(NULL,NULL));
 	g_assert(!validate_target(NULL,""));
 	g_assert(!validate_target("",NULL));
 	g_assert(!validate_target("",""));
-	
+
 	g_assert(!validate_target(table,NULL));
 	g_assert(!validate_target(table,""));
-	
-	for(i = 0; PASS[i] ; i++)
-	{
-		target = validate_target(table,PASS[i]);
+
+	for(i = 0; pass[i] ; i++) {
+		target = validate_target(table,pass[i]);
 		g_assert(target);
-		
+
 		if(i == 5)
 			g_assert(!g_ascii_strcasecmp(target, "sfos_CUSTOM1"));
 		else
-			g_assert(!g_ascii_strcasecmp(target, PASS[i]));
-		
+			g_assert(!g_ascii_strcasecmp(target, pass[i]));
+
 		g_free(target);
 	}
-	
-	for(i = 0; FAIL[i] ; i++)
-		g_assert(!validate_target(table,FAIL[i]));
+
+	for(i = 0; fail[i] ; i++)
+		g_assert(!validate_target(table,fail[i]));
 }
 
 static void test_iptables_plugin_validate_policy()
@@ -1733,7 +1699,7 @@ static void test_iptables_plugin_validate_policy()
 
 	g_assert(validate_policy("ACCEPT"));
 	g_assert(validate_policy("DROP"));
-	
+
 	g_assert(!validate_policy("accept"));
 	g_assert(!validate_policy("drop"));
 	g_assert(!validate_policy("Accept"));
@@ -1749,113 +1715,153 @@ static void test_iptables_plugin_validate_icmp()
 {
 	guint16 icmp[2] = {0};
 	int type = IPV4;
-	
+
 	g_assert(validate_icmp(type, icmp));
-	
+
 	icmp[0] = 8;
 	icmp[1] = 10;
-	
+
 	g_assert(validate_icmp(type, icmp));
-	
+
 	icmp[0] = 44;
-	
+
 	g_assert(!validate_icmp(type, icmp));
-	
+
 	icmp[0] = 8;
 	icmp[1] = 16;
-	
+
 	g_assert(!validate_icmp(type, icmp));
-	
+
 	icmp[0] = 44;
 	icmp[1] = 16;
-	
+
 	g_assert(!validate_icmp(type, icmp));
-	
+
 	type = IPV6;
 	icmp[0] = icmp[1] = 0;
-	
+
 	g_assert(validate_icmp(type, icmp));
-	
+
 	icmp[0] = 8;
 	icmp[1] = 10;
-	
+
 	g_assert(validate_icmp(type, icmp));
-	
+
 	icmp[0] = 161;
 	icmp[1] = 255;
-	
+
 	g_assert(validate_icmp(type, icmp));
-	
+
 	icmp[0] = 163;
-	
+
 	g_assert(!validate_icmp(type, icmp));
-	
+
 	icmp[0] = 161;
 	icmp[1] = 256;
-	
+
 	g_assert(!validate_icmp(type, icmp));
-	
+
 	icmp[0] = 200;
 	icmp[1] = 257;
-	
+
 	g_assert(!validate_icmp(type, icmp));
 }
 
-#define PREFIX				"/sailfish_connman_plugin_iptables_"
-#define PREFIX_VALIDATE			PREFIX"validate/"
-#define PREFIX_PARAMETERS		PREFIX"parameters/"
-#define PREFIX_UTILS			PREFIX"utils/"
-#define PREFIX_DBUS			PREFIX"dbus/"
+#define PREFIX			"/sailfish_connman_plugin_iptables_"
+#define PREFIX_VALIDATE		PREFIX"validate/"
+#define PREFIX_PARAMETERS	PREFIX"parameters/"
+#define PREFIX_UTILS		PREFIX"utils/"
+#define PREFIX_DBUS		PREFIX"dbus/"
 #define PREFIX_POLICY		PREFIX"policycheck/"
 
 
 int main(int argc, char *argv[])
 {	
 	g_test_init(&argc, &argv, NULL);
-	
-	g_test_add_func(PREFIX_VALIDATE "policy", test_iptables_plugin_validate_policy);
-	g_test_add_func(PREFIX_VALIDATE "port", test_iptables_plugin_validate_port);
-	g_test_add_func(PREFIX_VALIDATE "operation", test_iptables_plugin_validate_operation);
-	g_test_add_func(PREFIX_VALIDATE "protocol", test_iptables_plugin_validate_protocol);
-	g_test_add_func(PREFIX_VALIDATE "service_name", test_iptables_plugin_validate_service_name);
-	g_test_add_func(PREFIX_VALIDATE "ip_address", test_iptables_plugin_validate_ip_address);
-	g_test_add_func(PREFIX_VALIDATE "address", test_iptables_plugin_validate_address);
-	g_test_add_func(PREFIX_VALIDATE "mask", test_iptables_plugin_validate_mask);
-	g_test_add_func(PREFIX_VALIDATE "negated_ip_address", test_iptables_plugin_negated_ip_address);
-	g_test_add_func(PREFIX_VALIDATE "chain", test_iptables_plugin_validate_chain);
-	g_test_add_func(PREFIX_VALIDATE "target", test_iptables_plugin_validate_target);
-	g_test_add_func(PREFIX_VALIDATE "icmp", test_iptables_plugin_validate_icmp);
-	
-	g_test_add_func(PREFIX_PARAMETERS "check_operation", test_iptables_plugin_parameters_check_operation);
-	g_test_add_func(PREFIX_PARAMETERS "check_ips", test_iptables_plugin_parameters_check_ips);
-	g_test_add_func(PREFIX_PARAMETERS "check_ports", test_iptables_plugin_parameters_check_ports);
-	g_test_add_func(PREFIX_PARAMETERS "check_port_range", test_iptables_plugin_parameters_check_port_range);
-	g_test_add_func(PREFIX_PARAMETERS "check_service", test_iptables_plugin_parameters_check_service);
-	g_test_add_func(PREFIX_PARAMETERS "check_chain_restricted", test_iptables_plugin_parameters_check_chain_restricted);
-	g_test_add_func(PREFIX_PARAMETERS "check_icmp", test_iptables_plugin_parameters_check_icmp);
-	g_test_add_func(PREFIX_PARAMETERS "ip_full", test_iptables_plugin_parameters_ip_full);
-	g_test_add_func(PREFIX_PARAMETERS "port_full", test_iptables_plugin_parameters_port_full);
-	g_test_add_func(PREFIX_PARAMETERS "ip_and_port_full", test_iptables_plugin_parameters_ip_and_port_full);
-	g_test_add_func(PREFIX_PARAMETERS "ip_and_port_range_full", test_iptables_plugin_parameters_ip_and_port_range_full);
-	g_test_add_func(PREFIX_PARAMETERS "port_range_full", test_iptables_plugin_parameters_port_range_full);
-	g_test_add_func(PREFIX_PARAMETERS "service_full", test_iptables_plugin_parameters_service_full);
-	g_test_add_func(PREFIX_PARAMETERS "icmp_full", test_iptables_plugin_parameters_check_icmp_full);
-	g_test_add_func(PREFIX_PARAMETERS "chains", test_iptables_plugin_parameters_chain);
-	g_test_add_func(PREFIX_PARAMETERS "dbus_client", test_iptables_plugin_parameters_dbus_client);
-	g_test_add_func(PREFIX_PARAMETERS "api_data", test_iptables_plugin_parameters_api_data);
-	g_test_add_func(PREFIX_PARAMETERS "api_data_chains", test_iptables_plugin_parameters_api_data_chains);
-	g_test_add_func(PREFIX_PARAMETERS "custom_chain", test_iptables_plugin_parameters_custom_chains);
-	g_test_add_func(PREFIX_PARAMETERS "disconnect_data", test_iptables_plugin_parameters_disconnect_data);
-	
-	g_test_add_func(PREFIX_UTILS "protocol_for_service", test_iptables_plugin_utils_protocol_for_service);
-	g_test_add_func(PREFIX_UTILS "protocol_for_port", test_iptables_plugin_utils_protocol_for_port);
-	g_test_add_func(PREFIX_UTILS "mask_to_cidr", test_iptables_plugin_utils_mask_to_cidr);
-	g_test_add_func(PREFIX_UTILS "format_ip", test_iptables_plugin_utils_format_ip);
-	
-	g_test_add_func(PREFIX_POLICY "basic", test_iptables_plugin_policy_check_basic);
-	g_test_add_func(PREFIX_POLICY "root", test_iptables_plugin_policy_check_root);
-	g_test_add_func(PREFIX_POLICY "user", test_iptables_plugin_policy_check_user);
-	g_test_add_func(PREFIX_POLICY "load", test_iptables_plugin_policy_load);
+
+	g_test_add_func(PREFIX_VALIDATE "policy",
+		test_iptables_plugin_validate_policy);
+	g_test_add_func(PREFIX_VALIDATE "port",
+		test_iptables_plugin_validate_port);
+	g_test_add_func(PREFIX_VALIDATE "operation",
+		test_iptables_plugin_validate_operation);
+	g_test_add_func(PREFIX_VALIDATE "protocol",
+		test_iptables_plugin_validate_protocol);
+	g_test_add_func(PREFIX_VALIDATE "service_name",
+		test_iptables_plugin_validate_service_name);
+	g_test_add_func(PREFIX_VALIDATE "ip_address",
+		test_iptables_plugin_validate_ip_address);
+	g_test_add_func(PREFIX_VALIDATE "address",
+		test_iptables_plugin_validate_address);
+	g_test_add_func(PREFIX_VALIDATE "mask",
+		test_iptables_plugin_validate_mask);
+	g_test_add_func(PREFIX_VALIDATE "negated_ip_address",
+		test_iptables_plugin_negated_ip_address);
+	g_test_add_func(PREFIX_VALIDATE "chain",
+		test_iptables_plugin_validate_chain);
+	g_test_add_func(PREFIX_VALIDATE "target",
+		test_iptables_plugin_validate_target);
+	g_test_add_func(PREFIX_VALIDATE "icmp",
+		test_iptables_plugin_validate_icmp);
+
+	g_test_add_func(PREFIX_PARAMETERS "check_operation",
+		test_iptables_plugin_parameters_check_operation);
+	g_test_add_func(PREFIX_PARAMETERS "check_ips",
+		test_iptables_plugin_parameters_check_ips);
+	g_test_add_func(PREFIX_PARAMETERS "check_ports",
+		test_iptables_plugin_parameters_check_ports);
+	g_test_add_func(PREFIX_PARAMETERS "check_port_range",
+		test_iptables_plugin_parameters_check_port_range);
+	g_test_add_func(PREFIX_PARAMETERS "check_service",
+		test_iptables_plugin_parameters_check_service);
+	g_test_add_func(PREFIX_PARAMETERS "check_chain_restricted",
+		test_iptables_plugin_parameters_check_chain_restricted);
+	g_test_add_func(PREFIX_PARAMETERS "check_icmp",
+		test_iptables_plugin_parameters_check_icmp);
+	g_test_add_func(PREFIX_PARAMETERS "ip_full",
+		test_iptables_plugin_parameters_ip_full);
+	g_test_add_func(PREFIX_PARAMETERS "port_full",
+		test_iptables_plugin_parameters_port_full);
+	g_test_add_func(PREFIX_PARAMETERS "ip_and_port_full",
+		test_iptables_plugin_parameters_ip_and_port_full);
+	g_test_add_func(PREFIX_PARAMETERS "ip_and_port_range_full",
+		test_iptables_plugin_parameters_ip_and_port_range_full);
+	g_test_add_func(PREFIX_PARAMETERS "port_range_full",
+		test_iptables_plugin_parameters_port_range_full);
+	g_test_add_func(PREFIX_PARAMETERS "service_full",
+		test_iptables_plugin_parameters_service_full);
+	g_test_add_func(PREFIX_PARAMETERS "icmp_full",
+		test_iptables_plugin_parameters_check_icmp_full);
+	g_test_add_func(PREFIX_PARAMETERS "chains",
+		test_iptables_plugin_parameters_chain);
+	g_test_add_func(PREFIX_PARAMETERS "dbus_client",
+		test_iptables_plugin_parameters_dbus_client);
+	g_test_add_func(PREFIX_PARAMETERS "api_data",
+		test_iptables_plugin_parameters_api_data);
+	g_test_add_func(PREFIX_PARAMETERS "api_data_chains",
+		test_iptables_plugin_parameters_api_data_chains);
+	g_test_add_func(PREFIX_PARAMETERS "custom_chain",
+		test_iptables_plugin_parameters_custom_chains);
+	g_test_add_func(PREFIX_PARAMETERS "disconnect_data",
+		test_iptables_plugin_parameters_disconnect_data);
+
+	g_test_add_func(PREFIX_UTILS "protocol_for_service",
+		test_iptables_plugin_utils_protocol_for_service);
+	g_test_add_func(PREFIX_UTILS "protocol_for_port",
+		test_iptables_plugin_utils_protocol_for_port);
+	g_test_add_func(PREFIX_UTILS "mask_to_cidr",
+		test_iptables_plugin_utils_mask_to_cidr);
+	g_test_add_func(PREFIX_UTILS "format_ip",
+		test_iptables_plugin_utils_format_ip);
+
+	g_test_add_func(PREFIX_POLICY "basic",
+		test_iptables_plugin_policy_check_basic);
+	g_test_add_func(PREFIX_POLICY "root",
+		test_iptables_plugin_policy_check_root);
+	g_test_add_func(PREFIX_POLICY "user",
+		test_iptables_plugin_policy_check_user);
+	g_test_add_func(PREFIX_POLICY "load",
+		test_iptables_plugin_policy_load);
 
 	return g_test_run();
 }


### PR DESCRIPTION
Use "defaultuser" instead of "nemo in the tests and set to use correct path in the save tests. Set the end-to-end tests to depend on ```gnu-bash``` as busybox shell cannot run them. Cleanup the code mostly with regex to have it closer to ConnMan styling.