### PR TITLE
Fix e-t-e test for newer iptables and correct README

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,8 +191,10 @@ dbus-send --system \
 --print-reply \
 --dest="net.connman" \
 /org/sailfishos/connman/mdm/iptables \
-org.sailfishos.connman.mdm.iptables.ChangeInputPolicy \
-string:"drop"
+org.sailfishos.connman.mdm.iptables.ChangePolicy \
+string:"filter" \
+string:"input" \
+uint16:2
 ```
 
 ### Add rule to allow incoming connections from 192.168.0.1

--- a/rpm/sailfish-iptables-api-plugin.spec
+++ b/rpm/sailfish-iptables-api-plugin.spec
@@ -1,5 +1,5 @@
 Name: sailfish-connman-iptables-plugin
-Version: 0.0.8
+Version: 0.0.10
 Release: 1
 Summary: Sailfish Connman iptables management plugin
 License: BSD

--- a/test/ete-test/sailfish-connman-iptables-plugin-test
+++ b/test/ete-test/sailfish-connman-iptables-plugin-test
@@ -19,24 +19,24 @@ TEST_CHAINS="INPUT OUTPUT $CUSTOM_CHAIN"
 
 TEST_TARGETS="ACCEPT DROP REJECT $CUSTOM_CHAIN"
 
-IP_INPUTS[0]='string:192.168.10.1 string:'
-IP_INPUTS[1]='string: string:192.168.10.2'
-IP_INPUTS[2]='string:192.168.10.1 string:192.168.10.2'
+IP_INPUTS[0]='string:192.168.123.1 string:'
+IP_INPUTS[1]='string: string:192.168.123.2'
+IP_INPUTS[2]='string:192.168.123.1 string:192.168.123.2'
 IP_INPUTS[3]='' # Empty as last
 
-IP_VERIFY[0]='192.168.10.1'
-IP_VERIFY[1]='192.168.10.2'
-IP_VERIFY[2]='192.168.10.1.*192.168.10.2'
+IP_VERIFY[0]='192.168.123.1'
+IP_VERIFY[1]='192.168.123.2'
+IP_VERIFY[2]='192.168.123.1.*192.168.123.2'
 IP_VERIFY[3]=''
 
-IP_INPUTS_VERIFY[0]="all ${IP_VERIFY[0]}"
-IP_INPUTS_VERIFY[1]="all ${IP_VERIFY[1]}"
-IP_INPUTS_VERIFY[2]="all ${IP_VERIFY[2]}"
+IP_INPUTS_VERIFY[0]="0 ${IP_VERIFY[0]}"
+IP_INPUTS_VERIFY[1]="0 ${IP_VERIFY[1]}"
+IP_INPUTS_VERIFY[2]="0 ${IP_VERIFY[2]}"
 IP_INPUTS_VERIFY[3]=''
 
-PORT_VERIFY_PRE[0]='udp'
-PORT_VERIFY_PRE[1]='tcp'
-PORT_VERIFY_PRE[2]='tcp'
+PORT_VERIFY_PRE[0]='17' # UDP
+PORT_VERIFY_PRE[1]='6'  # TCP
+PORT_VERIFY_PRE[2]='6'  # TCP
 PORT_VERIFY_PRE[3]=''
 
 PORT_INPUTS[0]='uint16:23 uint16:0 uint32:17'
@@ -103,13 +103,13 @@ function include_sources()
 function run_method_test_check_change()
 {
 	if [ "$(id -u)" == "0" ] ; then
-	
+
 		if [ "$1" == "$CUSTOM_CHAIN" ] ; then
 			CHAIN="sfos_$1"
 		else
 			CHAIN="$1"
 		fi
-			
+
 		RESULT=$(check_change "$CHAIN" "$2" ${@:3})
 
 		if [[ "$RESULT" != "0" ]] ; then
@@ -128,13 +128,13 @@ function run_method_test_check_change()
 function run_method_test_check_removed()
 {
 	if [ "$(id -u)" == "0" ] ; then
-		
+
 		if [ "$1" == "$CUSTOM_CHAIN" ] ; then
 			CHAIN="sfos_$1"
 		else
 			CHAIN="$1"
 		fi
-		
+
 		RESULT=$(check_removed "$CHAIN" "$2" ${@:3})
 
 		if [[ "$RESULT" != "0" ]] ; then
@@ -157,32 +157,32 @@ function test_rule_ip()
 	for CHAIN in $TEST_CHAINS ; do
 		for TARGET in $TEST_TARGETS ; do
 			while [[ ! -z ${IP_INPUTS[$INDEX]} ]] ; do
-			
+
 				if [ "$CHAIN" != "$TARGET" ] ; then
 					RULE="${IP_INPUTS[$INDEX]}"
 					VERIFY="${IP_INPUTS_VERIFY[$INDEX]}"
 					FAILED=0
-			
+
 					test_begin
-					
+
 					RES=$(send_rule_message "$METHOD" "ADD" "$CHAIN" "$TARGET" "$RULE")
 					if [ "$RES" != "0" ] ; then FAILED=1 ; fi
 					test_progress
-					
+
 					RES=$(run_method_test_check_change "$CHAIN" "$TARGET" "$VERIFY")
 					if [ "$RES" != "0" ] ; then FAILED=1 ; fi
 					test_progress
-					
+
 					RES=$(send_rule_message "$METHOD" "REMOVE" "$CHAIN" "$TARGET" "$RULE")
 					if [ "$RES" != "0" ] ; then FAILED=1 ; fi
 					test_progress
-					
+
 					RES=$(run_method_test_check_removed "$CHAIN" "$TARGET" "$VERIFY")
 					if [ "$RES" != "0" ] ; then FAILED=1 ; fi
-					
+
 					test_end "$FAILED"
 				fi
-				
+
 				INDEX=$((INDEX+1))
 			done
 			INDEX=0
@@ -200,33 +200,33 @@ function test_rule_ip_port()
 		for TARGET in $TEST_TARGETS ; do
 			while [[ ! -z ${IP_INPUTS[$INDEX_IP]} ]] ; do
 				while [[ ! -z ${PORT_INPUTS[$INDEX]} ]] ; do
-			
+
 					if [ "$CHAIN" != "$TARGET" ] ; then
 						RULE="${IP_INPUTS[$INDEX_IP]} ${PORT_INPUTS[$INDEX]}"
 						VERIFY="${PORT_VERIFY_PRE[$INDEX]} ${IP_VERIFY[$INDEX_IP]} ${PORT_INPUTS_VERIFY[$INDEX]}"
 						FAILED=0
-			
+
 						test_begin
-					
+
 						RES=$(send_rule_message "$METHOD" "ADD" "$CHAIN" "$TARGET" "$RULE")
 						if [ "$RES" != "0" ] ; then FAILED=1 ; fi
 						test_progress
-					
+
 						RES=$(run_method_test_check_change "$CHAIN" "$TARGET" "$VERIFY")
 						if [ "$RES" != "0" ] ; then FAILED=1 ; fi
 						test_progress
-					
+
 						RES=$(send_rule_message "$METHOD" "REMOVE" "$CHAIN" "$TARGET" "$RULE")
 						if [ "$RES" != "0" ] ; then FAILED=1 ; fi
 						test_progress
-					
+
 						RES=$(run_method_test_check_removed "$CHAIN" "$TARGET" "$VERIFY")
 						if [ "$RES" != "0" ] ; then FAILED=1 ; fi
-					
+
 						test_end "$FAILED"
 					fi
 					INDEX=$((INDEX+1))
-					
+
 				done
 				INDEX=0
 				INDEX_IP=$((INDEX_IP+1))
@@ -250,24 +250,24 @@ function test_rule_ip_port_range()
 						RULE="${IP_INPUTS[$INDEX_IP]} ${PORT_RANGE_INPUTS[$INDEX]}"
 						VERIFY="${PORT_VERIFY_PRE[$INDEX]} ${IP_VERIFY[$INDEX_IP]} ${PORT_RANGE_INPUTS_VERIFY[$INDEX]}"
 						FAILED=0
-			
+
 						test_begin
-					
+
 						RES=$(send_rule_message "$METHOD" "ADD" "$CHAIN" "$TARGET" "$RULE")
 						if [ "$RES" != "0" ] ; then FAILED=1 ; fi
 						test_progress
-					
+
 						RES=$(run_method_test_check_change "$CHAIN" "$TARGET" "$VERIFY")
 						if [ "$RES" != "0" ] ; then FAILED=1 ; fi
 						test_progress
-					
+
 						RES=$(send_rule_message "$METHOD" "REMOVE" "$CHAIN" "$TARGET" "$RULE")
 						if [ "$RES" != "0" ] ; then FAILED=1 ; fi
 						test_progress
-					
+
 						RES=$(run_method_test_check_removed "$CHAIN" "$TARGET" "$VERIFY")
 						if [ "$RES" != "0" ] ; then FAILED=1 ; fi
-					
+
 						test_end "$FAILED"
 					fi
 					INDEX=$((INDEX+1))
@@ -294,24 +294,24 @@ function test_rule_ip_service()
 						RULE="${IP_INPUTS[$INDEX_IP]} ${SERVICE_INPUTS[$INDEX]}"
 						VERIFY="${PORT_VERIFY_PRE[$INDEX]} ${IP_VERIFY[$INDEX_IP]} ${PORT_INPUTS_VERIFY[$INDEX]}"
 						FAILED=0
-			
+
 						test_begin
-					
+
 						RES=$(send_rule_message "$METHOD" "ADD" "$CHAIN" "$TARGET" "$RULE")
 						if [ "$RES" != "0" ] ; then FAILED=1 ; fi
 						test_progress
-					
+
 						RES=$(run_method_test_check_change "$CHAIN" "$TARGET" "$VERIFY")
 						if [ "$RES" != "0" ] ; then FAILED=1 ; fi
 						test_progress
-					
+
 						RES=$(send_rule_message "$METHOD" "REMOVE" "$CHAIN" "$TARGET" "$RULE")
 						if [ "$RES" != "0" ] ; then FAILED=1 ; fi
 						test_progress
-					
+
 						RES=$(run_method_test_check_removed "$CHAIN" "$TARGET" "$VERIFY")
 						if [ "$RES" != "0" ] ; then FAILED=1 ; fi
-					
+
 						test_end "$FAILED"
 					fi
 					INDEX=$((INDEX+1))
@@ -336,27 +336,27 @@ function test_rule_port()
 					RULE="${PORT_INPUTS[$INDEX]}"
 					VERIFY="${PORT_VERIFY_PRE[$INDEX]} ${PORT_INPUTS_VERIFY[$INDEX]}"
 					FAILED=0
-	
+
 					test_begin
-					
+
 					RES=$(send_rule_message "$METHOD" "ADD" "$CHAIN" "$TARGET" "$RULE")
 					if [ "$RES" != "0" ] ; then FAILED=1 ; fi
 					test_progress
-				
+
 					RES=$(run_method_test_check_change "$CHAIN" "$TARGET" "$VERIFY")
 					if [ "$RES" != "0" ] ; then FAILED=1 ; fi
 					test_progress
-				
+
 					RES=$(send_rule_message "$METHOD" "REMOVE" "$CHAIN" "$TARGET" "$RULE")
 					if [ "$RES" != "0" ] ; then FAILED=1 ; fi
 					test_progress
-				
+
 					RES=$(run_method_test_check_removed "$CHAIN" "$TARGET" "$VERIFY")
 					if [ "$RES" != "0" ] ; then FAILED=1 ; fi
-				
+
 					test_end "$FAILED"
 				fi
-			
+
 				INDEX=$((INDEX+1))
 			done
 			INDEX=0
@@ -376,27 +376,27 @@ function test_rule_port_range()
 					RULE="${PORT_RANGE_INPUTS[$INDEX]}"
 					VERIFY="${PORT_VERIFY_PRE[$INDEX]} ${PORT_RANGE_INPUTS_VERIFY[$INDEX]}"
 					FAILED=0
-		
+
 					test_begin
-					
+
 					RES=$(send_rule_message "$METHOD" "ADD" "$CHAIN" "$TARGET" "$RULE")
 					if [ "$RES" != "0" ] ; then FAILED=1 ; fi
 					test_progress
-				
+
 					RES=$(run_method_test_check_change "$CHAIN" "$TARGET" "$VERIFY")
 					if [ "$RES" != "0" ] ; then FAILED=1 ; fi
 					test_progress
-				
+
 					RES=$(send_rule_message "$METHOD" "REMOVE" "$CHAIN" "$TARGET" "$RULE")
 					if [ "$RES" != "0" ] ; then FAILED=1 ; fi
 					test_progress
-				
+
 					RES=$(run_method_test_check_removed "$CHAIN" "$TARGET" "$VERIFY")
 					if [ "$RES" != "0" ] ; then FAILED=1 ; fi
-				
+
 					test_end "$FAILED"
 				fi
-			
+
 				INDEX=$((INDEX+1))
 			done
 			INDEX=0
@@ -416,27 +416,27 @@ function test_rule_service()
 					RULE="${SERVICE_INPUTS[$INDEX]}"
 					VERIFY="${PORT_VERIFY_PRE[$INDEX]} ${PORT_INPUTS_VERIFY[$INDEX]}"
 					FAILED=0
-		
+
 					test_begin
-					
+
 					RES=$(send_rule_message "$METHOD" "ADD" "$CHAIN" "$TARGET" "$RULE")
 					if [ "$RES" != "0" ] ; then FAILED=1 ; fi
 					test_progress
-				
+
 					RES=$(run_method_test_check_change "$CHAIN" "$TARGET" "$VERIFY")
 					if [ "$RES" != "0" ] ; then FAILED=1 ; fi
 					test_progress
-				
+
 					RES=$(send_rule_message "$METHOD" "REMOVE" "$CHAIN" "$TARGET" "$RULE")
 					if [ "$RES" != "0" ] ; then FAILED=1 ; fi
 					test_progress
-				
+
 					RES=$(run_method_test_check_removed "$CHAIN" "$TARGET" "$VERIFY")
 					if [ "$RES" != "0" ] ; then FAILED=1 ; fi
-				
+
 					test_end "$FAILED"
 				fi
-			
+
 				INDEX=$((INDEX+1))
 			done
 			INDEX=0
@@ -454,30 +454,30 @@ function test_rule_icmp()
 			while [[ ! -z ${ICMP_INPUTS[$INDEX]} ]] ; do
 				if [ "$CHAIN" != "$TARGET" ] ; then
 					RULE="string: string: ${ICMP_INPUTS[$INDEX]}"
-					VERIFY="icmp ${ICMP_INPUTS_VERIFY[$INDEX]}"
+					VERIFY="1 ${ICMP_INPUTS_VERIFY[$INDEX]}"
 					FAILED=0
-		
+
 					test_begin
-				
+
 					RES=$(send_rule_message "$METHOD" "ADD" "$CHAIN" "$TARGET" "$RULE")
 					if [ "$RES" != "0" ] ; then FAILED=1 ; fi
 					test_progress
-				
+
 					RES=$(run_method_test_check_change "$CHAIN" "$TARGET" "$VERIFY")
 					if [ "$RES" != "0" ] ; then FAILED=1 ; fi
 					test_progress
-				
+
 					RES=$(send_rule_message "$METHOD" "REMOVE" "$CHAIN" "$TARGET" "$RULE")
 					if [ "$RES" != "0" ] ; then FAILED=1 ; fi
 					test_progress
-				
+
 					RES=$(run_method_test_check_removed "$CHAIN" "$TARGET" "$VERIFY")
 					if [ "$RES" != "0" ] ; then FAILED=1 ; fi
-				
+
 					test_end "$FAILED"
 				fi
 				INDEX=$((INDEX+1))
-				
+
 			done
 			INDEX=0
 		done
@@ -494,33 +494,33 @@ function test_rule_icmp_ip()
 		for TARGET in $TEST_TARGETS ; do
 			while [[ ! -z ${IP_INPUTS[$INDEX_IP]} ]] ; do
 				while [[ ! -z ${ICMP_INPUTS[$INDEX]} ]] ; do
-			
+
 					if [ "$CHAIN" != "$TARGET" ] ; then
 						RULE="${IP_INPUTS[$INDEX_IP]} ${ICMP_INPUTS[$INDEX]}"
-						VERIFY="icmp ${IP_VERIFY[$INDEX_IP]} ${ICMP_INPUTS_VERIFY[$INDEX]}"
+						VERIFY="1 ${IP_VERIFY[$INDEX_IP]} ${ICMP_INPUTS_VERIFY[$INDEX]}"
 						FAILED=0
-			
+
 						test_begin
-					
+
 						RES=$(send_rule_message "$METHOD" "ADD" "$CHAIN" "$TARGET" "$RULE")
 						if [ "$RES" != "0" ] ; then FAILED=1 ; fi
 						test_progress
-					
+
 						RES=$(run_method_test_check_change "$CHAIN" "$TARGET" "$VERIFY")
 						if [ "$RES" != "0" ] ; then FAILED=1 ; fi
 						test_progress
-					
+
 						RES=$(send_rule_message "$METHOD" "REMOVE" "$CHAIN" "$TARGET" "$RULE")
 						if [ "$RES" != "0" ] ; then FAILED=1 ; fi
 						test_progress
-					
+
 						RES=$(run_method_test_check_removed "$CHAIN" "$TARGET" "$VERIFY")
 						if [ "$RES" != "0" ] ; then FAILED=1 ; fi
-					
+
 						test_end "$FAILED"
 					fi
 					INDEX=$((INDEX+1))
-					
+
 				done
 				INDEX=0
 				INDEX_IP=$((INDEX_IP+1))
@@ -534,25 +534,25 @@ function test_rule_pre()
 {
 	test_begin
 	FAILED=0
-		
+
 	STATUS=$(send_message "ManageChain" "ADD" $CHAIN_RESULT "string:filter" "string:$CUSTOM_CHAIN")
-	
+
 	if [[ "$STATUS" != "0" ]] ; then
 		log "$STATUS"
 		FAILED=1
 	fi
-	
+
 	test_progress
-	
+
 	if [ "$(id -u)" == "0" ] ; then
 		STATUS=$(check_chain_added "$CUSTOM_CHAIN")
-	
+
 		if [[ "$STATUS" != "0" ]] ; then
 			log "$STATUS"
 			FAILED=1
 		fi
 	fi
-	
+
 	test_end $FAILED
 }
 
@@ -560,25 +560,25 @@ function test_rule_post()
 {
 	test_begin
 	FAILED=0
-		
+
 	STATUS=$(send_message "ManageChain" "REMOVE" $CHAIN_RESULT "string:filter" "string:$CUSTOM_CHAIN")
-	
+
 	if [[ "$STATUS" != "0" ]] ; then
 		log "$STATUS"
 		FAILED=1
 	fi
-	
+
 	test_progress
-	
+
 	if [ "$(id -u)" == "0" ] ; then
 		STATUS=$(check_chain_removed "$CUSTOM_CHAIN")
-	
+
 		if [[ "$STATUS" != "0" ]] ; then
 			log "$STATUS"
 			FAILED=1
 		fi
 	fi
-	
+
 	test_end $FAILED
 }
 
@@ -602,36 +602,36 @@ function run_policy_tests()
 	METHOD="ChangePolicy"
 	CHAINS="INPUT OUTPUT FORWARD"
 	POLICIES="DROP ACCEPT"
-	
+
 	for CHAIN in $CHAINS ; do
 		for POLICY in $POLICIES ; do
-		
+
 			FAILED=0
 			test_begin
-	
+
 			PROCESSED=$(send_message "$METHOD" "$POLICY" "$POLICY_RESULT" "string:filter" "string:$CHAIN")
-	
+
 			test_progress
-	
+
 			if [[ "$PROCESSED" != "0" ]] ; then
 				log "$PROCESSED"
 				FAILED=1
 			fi
-	
+
 			test_progress
-	
+
 			# Checking of policy change only possible for root, hence iptables command
 			if [ "$(id -u)" == "0" ] ; then
 				CHANGE=$(check_policy_change "$CHAIN" "$POLICY")
-	
+
 				if [[ "$CHANGE" != "0" ]] ; then
 					log "$CHANGE"
 					FAILED=1
 				fi
 			fi
-	
+
 			test_progress
-	
+
 			test_end $FAILED
 		done
 	done
@@ -640,18 +640,18 @@ function run_policy_tests()
 function run_clear_test()
 {
 	FAILED=0
-	
+
 	test_begin
-	
+
 	CLEARED=$(send_message "ClearIptablesTable" "filter" "$CLEAR_RESULT")
-	
+
 	test_progress
-	
+
 	if [[ "$CLEARED" != "0" ]] ; then
 		log "$CLEARED"
 		FAILED=1
 	fi
-	
+
 	test_end $FAILED
 }
 
@@ -660,25 +660,25 @@ function run_register_tests()
 	# 1. unregister, 11 for all
 	# 2. register, 0 for root, privileged, 12 for defaultuser
 	# 3. unregister, 11 for all since dbus-send quits after send
-	
+
 	MESSAGES="Unregister Register Unregister"
 	INDEX=0
-	
+
 	for MSG in $MESSAGES ; do
 		FAILED=0
 		test_begin
-	
+
 		STATUS=$(send_message "$MSG" "" "${REGISTER_TEST_RESULT[$INDEX]}")
-		
+
 		test_progress
-	
+
 		if [[ "$STATUS" != "0" ]] ; then
 			log "$STATUS"
 			FAILED=1
 		fi
-		
+
 		test_end $FAILED
-		
+
 		INDEX=$((INDEX+1))
 	done
 }
@@ -686,53 +686,53 @@ function run_register_tests()
 function run_chain_management_tests()
 {
 	CHAINS_PASS="TESTCHAIN1 TESTCHAIN2"
-	
+
 	for CHAIN in $CHAINS_PASS ; do
-	
+
 		FAILED=0
-	
+
 		test_begin
-		
+
 		STATUS=$(send_message "ManageChain" "ADD" $CHAIN_RESULT "string:filter" "string:$CHAIN")
-		
+
 		if [[ "$STATUS" != "0" ]] ; then
 			log "$STATUS"
 			FAILED=1
 		fi
-		
+
 		test_progress
-		
+
 		if [ "$(id -u)" == "0" ] ; then
 			STATUS=$(check_chain_added "$CHAIN")
-		
+
 			if [[ "$STATUS" != "0" ]] ; then
 				log "$STATUS"
 				FAILED=1
 			fi
 		fi
-		
+
 		test_progress
-		
+
 		STATUS=$(send_message "ManageChain" "REMOVE" $CHAIN_RESULT "string:filter" "string:$CHAIN")
-		
+
 		if [[ "$STATUS" != "0" ]] ; then
 			log "$STATUS"
 			FAILED=1
 		fi
-		
+
 		test_progress
-		
+
 		if [ "$(id -u)" == "0" ] ; then
 			STATUS=$(check_chain_removed "$CHAIN")
-		
+
 			if [[ "$STATUS" != "0" ]] ; then
 				log "$STATUS"
 				FAILED=1
 			fi
 		fi
-		
+
 		test_progress
-		
+
 		test_end $FAILED
 	done
 }
@@ -745,13 +745,13 @@ function run_tests()
 			run_clear_test
 			;;
 	esac
-	
+
 	run_rule_tests
-	
+
 	run_policy_tests
-	
+
 	run_register_tests
-	
+
 	run_chain_management_tests
 }
 
@@ -779,15 +779,15 @@ function run_pre_test_operations()
 	if [ "$(id -u)" == "0" ] ; then
 		echo "Saving current iptables filter table to $IPTABLES_SAVE_FILE"
 		iptables-save --table=filter > $IPTABLES_SAVE_FILE
-	
+
 		CLEARED=$(send_message "ClearIptablesTable" "filter" "$CLEAR_RESULT")
-	
+
 		if [[ "$CLEARED" != "0" ]] ; then
 			echo "Cannot clear iptables filter table. Test may report invalid results."
 		fi
-		
+
 		CLEARED=$(send_message "ClearIptablesChains" "filter" "$CLEAR_RESULT")
-	
+
 		if [[ "$CLEARED" != "0" ]] ; then
 			echo "Cannot clear chains from iptables filter table. Test may report invalid results."
 		fi
@@ -798,7 +798,7 @@ function run_post_test_operations()
 {
 	if [ "$(id -u)" == "0" ] ; then
 		CLEARED=$(send_message "ClearIptablesTable" "filter" "$CLEAR_RESULT")
-	
+
 		if [[ "$CLEARED" != "0" ]] ; then
 			echo "Cannot clear iptables filter table."
 		fi
@@ -816,14 +816,14 @@ function run_user_checks()
 			exit 1
 		fi
 	done
-	
+
 	for GROUP in $REQUIRED_GROUPS ; do
 		if ! grep /etc/group -q -e "$GROUP" ; then 
 			echo "Group \"$GROUP\" does not exist in the system, test cannot be run."
 			exit 1
 		fi
 	done
-	
+
 	if [[ $(groups|grep privileged) ]] ; then
 		PRIVILEGED=1
 	fi
@@ -855,28 +855,28 @@ function set_expected_result()
 function main()
 {
 	include_sources
-	
+
 	prepare_log "ete-test"
 
 	run_user_checks # for all users
 	run_command_checks # for each user
-	
+
 	if [[ $PRIVILEGED -eq 1 ]] ; then
 		echo "Running tests with privileged group permissions"
 	else
 		echo "Running tests as $(whoami)"
 	fi
-	
+
 	run_pre_test_operations # only with root
-	
+
 	sleep 2
-	
+
 	set_expected_result
 
 	run_tests # for each user
-	
+
 	run_post_test_operations #only with root
-	
+
 	test_finalize "$TEST_LOG_FILE"
 }
 


### PR DESCRIPTION
End-to-end tests had protocols as strings in verification. Newer iptables seems to now output only numeric protocols from /etc/protocols when `-n` switch is used for listing and this required change for the tests to pass as the verification relies on the protocol.

Corrected the policy change example in README.md. Plus regex cleanup of excess tabs.